### PR TITLE
Update protobuf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "grpcio>=1.30.0",
     "grpcio-tools>=1.39.0",
-    "protobuf~=3.19",
+    "protobuf>=3.19",
     "google-api-python-client>=1.7.11",
     "googleapis-common-protos>=1.52.0",
 ]


### PR DESCRIPTION
Limiting `protobuf~=3.19` means that users of Python 3.11 can only install it if they have C++ build tools locally.

This PR simply permits the use of the latest `protobuf`.