### PR TITLE
Fdeleonm branch

### DIFF
--- a/docker/solver/README.rst
+++ b/docker/solver/README.rst
@@ -35,10 +35,6 @@ Prerequisites
 
      >>> Dockerfile README.rst do_build docker-compose.yml docker_dir mpi mppdyna_docker_centos7.zip
 
-* Within docker_dir, there is a file called mppdyna. This file is the executable to run. It can be
-  any executable (SMP, MPP) or revision and branch. To run a given file, the name shall be changed to
-  mppdyna and copied inside docker_dir.
-
 Once all prerequisites are met, you can build the Docker image for the ``solver`` service.
 
 Build the Docker image

--- a/docker/solver/README.rst
+++ b/docker/solver/README.rst
@@ -35,6 +35,10 @@ Prerequisites
 
      >>> Dockerfile README.rst do_build docker-compose.yml docker_dir mpi mppdyna_docker_centos7.zip
 
+* Within docker_dir, there is a file called mppdyna. This file is the executable to run. It can be
+  any executable (SMP, MPP) or revision and branch. To run a given file, the name shall be changed to
+  mppdyna and copied inside docker_dir.
+
 Once all prerequisites are met, you can build the Docker image for the ``solver`` service.
 
 Build the Docker image

--- a/docker/solver/do_build
+++ b/docker/solver/do_build
@@ -8,8 +8,6 @@ ssh-keygen -q -b 2048 -f ssh/id_rsa -N ""
 echo "Host *" > ssh/config
 echo "  StrictHostKeyChecking no" >> ssh/config
 #
-chmod -R 755 *
-#
 # Build container
 #
 docker build -t dyna_solver_v04 . 

--- a/docker/solver/do_build
+++ b/docker/solver/do_build
@@ -8,6 +8,8 @@ ssh-keygen -q -b 2048 -f ssh/id_rsa -N ""
 echo "Host *" > ssh/config
 echo "  StrictHostKeyChecking no" >> ssh/config
 #
+chmod -R 755 *
+#
 # Build container
 #
 docker build -t dyna_solver_v04 . 


### PR DESCRIPTION
- Add comment within README.rst regarding dyna executables (it is important for the user to know that, right now, the executable to be used needs to be named "mppdyna" **and** added to the docker_dir before creating the image. 
- Add chmod line in do_build to give required rights before creating docker image. After struggling for days I found out that some of the directories didn't have all required rights for executables to run (python scripts, mpi executables, etc). Adding an extra line to do_build solves all the issues. 