### PR TITLE
remove default dest

### DIFF
--- a/src/ansys/dyna/core/pre/examples/download_utilities.py
+++ b/src/ansys/dyna/core/pre/examples/download_utilities.py
@@ -4,6 +4,8 @@ from typing import Optional
 from urllib.parse import urljoin
 import urllib.request
 
+from ansys.dyna.core.pre.internals.defaults import EXAMPLES_PATH
+
 __all__ = ["DownloadManager"]
 
 
@@ -122,6 +124,8 @@ class DownloadManager(metaclass=DownloadManagerMeta):
         return saved_file
 
     def _retrieve_data(self, url: str, filename: str, dest: str = None, force: bool = False):
+        if dest == None:
+            dest = EXAMPLES_PATH
         local_path = os.path.join(dest, os.path.basename(filename))
         if not force and os.path.isfile(local_path):
             return local_path

--- a/src/ansys/dyna/core/pre/examples/download_utilities.py
+++ b/src/ansys/dyna/core/pre/examples/download_utilities.py
@@ -4,8 +4,6 @@ from typing import Optional
 from urllib.parse import urljoin
 import urllib.request
 
-import ansys.meshing.prime.internals.defaults as defaults
-
 __all__ = ["DownloadManager"]
 
 
@@ -124,8 +122,6 @@ class DownloadManager(metaclass=DownloadManagerMeta):
         return saved_file
 
     def _retrieve_data(self, url: str, filename: str, dest: str = None, force: bool = False):
-        if dest is None:
-            dest = defaults.get_examples_path()
         local_path = os.path.join(dest, os.path.basename(filename))
         if not force and os.path.isfile(local_path):
             return local_path

--- a/src/ansys/dyna/core/pre/internals/defaults.py
+++ b/src/ansys/dyna/core/pre/internals/defaults.py
@@ -17,14 +17,14 @@ import os
 try:
     import appdirs
 
-    USER_DATA_PATH = os.getenv("PYPRIMEMESH_USER_DATA", appdirs.user_data_dir(appname="pyprimemesh", appauthor=False))
+    USER_DATA_PATH = os.getenv("PYDYNA_USER_DATA", appdirs.user_data_dir(appname="pydyna", appauthor=False))
 except ModuleNotFoundError:
     # If appdirs is not installed, then try with tempfile.
     # NOTE: This only occurs for ADO ARM Test runs
     import tempfile
 
-    USER_NAME = os.getenv("USERNAME", os.getenv("USER", "pyprimemesh"))
-    USER_DATA_PATH = os.getenv("PYPRIMEMESH_USER_DATA", os.path.join(tempfile.gettempdir(), USER_NAME))
+    USER_NAME = os.getenv("USERNAME", os.getenv("USER", "pydyna"))
+    USER_DATA_PATH = os.getenv("PYDYNA_USER_DATA", os.path.join(tempfile.gettempdir(), USER_NAME))
 
 if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
     os.makedirs(USER_DATA_PATH)


### PR DESCRIPTION
It was errantly pointing to a PRIME folder. We don't need a default destination for pydyna (at least not yet)

This is a problem because I can't import the examples module unless I have PyPrime in my environment, and pyprime is not a dependency

@RobPasMue this still isn't quite right. I think it's strange that many pyansys libraries have a downloader module or a download manager class.  I think it can be error prone, shouldn't there be something more common they can all use (and customize some specific defaults?)