### PR TITLE
fix: make pr-check-title independent

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -53,7 +53,6 @@ jobs:
   code-style:
     name: "Code style"
     runs-on: ubuntu-latest
-    needs: pr-name
     steps:
       - uses: ansys/actions/code-style@v8
         with:
@@ -92,7 +91,6 @@ jobs:
   doc-style:
     name: "Documentation style"
     runs-on: ubuntu-latest
-    needs: pr-name
     steps:
       - name: PyAnsys documentation style checks
         uses: ansys/actions/doc-style@v8

--- a/doc/changelog/624.miscellaneous.md
+++ b/doc/changelog/624.miscellaneous.md
@@ -1,0 +1,1 @@
+fix: make pr-check-title independent


### PR DESCRIPTION
This pull-request ensures that the check of the pull-request title is independent. Otherwise, the CI/CD fails silently when releasing a new version, see https://github.com/ansys/pydyna/actions/runs/11935991135