### PR TITLE
fix: warn out of bounds characters when reading lines

### DIFF
--- a/doc/changelog/647.miscellaneous.md
+++ b/doc/changelog/647.miscellaneous.md
@@ -1,0 +1,1 @@
+fix: warn out of bounds characters when reading lines

--- a/src/ansys/dyna/core/lib/kwd_line_formatter.py
+++ b/src/ansys/dyna/core/lib/kwd_line_formatter.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import typing
+import warnings
 
 from ansys.dyna.core.lib.parameter_set import ParameterSet
 
@@ -146,6 +147,7 @@ def load_dataline(spec: typing.List[tuple], line_data: str, parameter_set: Param
         data.append(value)
 
     if end_position < len(line_data):
-        raise Exception("Data line is too long!")
+        warning_message = f'Detected out of bound card characters:\n"{line_data[end_position:]}"\n"Ignoring.'
+        warnings.warn(warning_message)
 
     return tuple(data)

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -40,7 +40,7 @@ def test_load_card_errors(string_utils):
         # cards can only load a readable buffer
         card.read("")
 
-    with pytest.raises(Exception):
+    with pytest.warns(UserWarning, match="Detected out of bound card characters"):
         # error if the line that is too long
         buf = "                                           "
         card.read(string_utils.as_buffer(buf))

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -162,6 +162,11 @@ $#   secid      area     thick
     # ensure that it does not throw when the data line is empty
     belt.loads(seatbelt_text)
 
+    seatbelt_text = seatbelt_text + "..."
+    # ensure that it does not throw when extra characters are added
+    with pytest.warns(UserWarning, match="Detected out of bound card characters"):
+        belt.loads(seatbelt_text)
+
 
 @pytest.mark.keywords
 def test_read_nodes(ref_string):

--- a/tests/test_load_dataline.py
+++ b/tests/test_load_dataline.py
@@ -65,7 +65,7 @@ def test_load_dataline_005():
 @pytest.mark.keywords
 def test_load_dataline_006():
     """test loading a data line that is too long."""
-    with pytest.raises(Exception):
+    with pytest.warns(UserWarning, match="Detected out of bound card characters"):
         load_dataline([(0, 8, int), (8, 8, float), (16, 8, float)], "                                          ")
 
 


### PR DESCRIPTION
Fixes #617 