### PR TITLE
feat: Fix *CONSTRAINED_ADAPTIVITY (#650)

### DIFF
--- a/codegen/manifest.json
+++ b/codegen/manifest.json
@@ -1916,6 +1916,16 @@
             ]
         }
     },
+    "CONSTRAINED_ADAPTIVITY": {
+        "generation-options": {
+            "duplicate-card": [
+                {
+                    "index": 0,
+                    "property-name": "constrains"
+                }
+            ]
+        }
+    },
     "CONSTRAINED_NODAL_RIGID_BODY": {
         "generation-options": {
             "duplicate-card-group": [

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/constrained_adaptivity.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/constrained_adaptivity.py
@@ -23,6 +23,7 @@
 import typing
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.config import use_lspp_defaults
+from ansys.dyna.core.lib.duplicate_card import DuplicateCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
 
 class ConstrainedAdaptivity(KeywordBase):
@@ -34,60 +35,23 @@ class ConstrainedAdaptivity(KeywordBase):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._cards = [
-            Card(
+            DuplicateCard(
                 [
-                    Field(
-                        "dnid",
-                        int,
-                        0,
-                        10,
-                        kwargs.get("dnid")
-                    ),
-                    Field(
-                        "nid1",
-                        int,
-                        10,
-                        10,
-                        kwargs.get("nid1")
-                    ),
-                    Field(
-                        "nid2",
-                        int,
-                        20,
-                        10,
-                        kwargs.get("nid2")
-                    ),
+                    Field("dnid", int, 0, 10),
+                    Field("nid1", int, 10, 10),
+                    Field("nid2", int, 20, 10),
                 ],
-            ),
+                None,
+                data = kwargs.get("constrains")),
         ]
 
     @property
-    def dnid(self) -> typing.Optional[int]:
-        """Get or set the Dependent node. This is the node constrained at the midpoint of an edge of an element.
-        """ # nopep8
-        return self._cards[0].get_value("dnid")
+    def constrains(self):
+        '''Gets the table of constrains'''
+        return self._cards[0].table
 
-    @dnid.setter
-    def dnid(self, value: int) -> None:
-        self._cards[0].set_value("dnid", value)
-
-    @property
-    def nid1(self) -> typing.Optional[int]:
-        """Get or set the Node at one end of an element edge
-        """ # nopep8
-        return self._cards[0].get_value("nid1")
-
-    @nid1.setter
-    def nid1(self, value: int) -> None:
-        self._cards[0].set_value("nid1", value)
-
-    @property
-    def nid2(self) -> typing.Optional[int]:
-        """Get or set the Node at the other end of that same element edge.
-        """ # nopep8
-        return self._cards[0].get_value("nid2")
-
-    @nid2.setter
-    def nid2(self, value: int) -> None:
-        self._cards[0].set_value("nid2", value)
+    @constrains.setter
+    def constrains(self, df):
+        '''sets constrains from the dataframe df'''
+        self._cards[0].table = df
 

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -721,6 +721,13 @@ def test_mat295_read(ref_string):
 
 
 @pytest.mark.keywords
+def test_constrained_adaptivity(ref_string):
+    ca = kwd.ConstrainedAdaptivity()
+    ca.loads(ref_string.test_constrained_adaptivity)
+    assert ca.constrains.shape == (5, 3)
+
+
+@pytest.mark.keywords
 def test_constrained_nodal_rigid_body_inertia_title(ref_string):
     c = kwd.ConstrainedNodalRigidBodyInertia()
     c.loads(ref_string.test_constrained_nodal_rigid_body_inertia_title)

--- a/tests/testfiles/keywords/reference_string.py
+++ b/tests/testfiles/keywords/reference_string.py
@@ -128,6 +128,15 @@ mat24
         0.        0.        0.        0.        0.        0.        0.        0.
         0.        0.        0.        0.        0.        0.        0.        0."""
 
+test_constrained_adaptivity = """*CONSTRAINED_ADAPTIVITY
+$#    dnid      nid1      nid2
+   4002345       400       381
+   4002378       419       400
+   4007434   4002346       401
+   4007433   4002377   4002346
+   4007430   4002379   4002377"""
+
+
 test_constrained_nodal_rigid_body_inertia_title = """*CONSTRAINED_NODAL_RIGID_BODY_INERTIA_TITLE
 Rigid Body Connection Element
   69002781            69000269                   0         0         0


### PR DESCRIPTION
import_file in ansys.dyna.core.lib.deck did not handle *CONSTRAINED_ADAPTIVITY correctly. This is fixed by creating the proper manifest entry for *CONSTRAINED_ADAPTIVITY card 0. This is now a duplicate card instead of a standard card.
