### PR TITLE
fix: Support multiline include

### DIFF
--- a/codegen/generate.py
+++ b/codegen/generate.py
@@ -35,6 +35,7 @@ import typing
 from jinja2 import Environment, FileSystemLoader
 
 from keyword_generation.handlers.shared_field import SharedFieldHandler
+from keyword_generation.handlers.external_card import ExternalCardHandler
 from keyword_generation.handlers.handler_base import KeywordHandler
 
 
@@ -343,6 +344,7 @@ HANDLERS = collections.OrderedDict(
         "rename-property": handle_rename_property,
         "skip-card": handle_skipped_cards,
         "duplicate-card-group": handle_duplicate_card_group,
+        "external-card-implementation": ExternalCardHandler(),
         "shared-field": SharedFieldHandler(),
         "override-subkeyword": handle_override_subkeyword,
     }

--- a/codegen/keyword_generation/handlers/external_card.py
+++ b/codegen/keyword_generation/handlers/external_card.py
@@ -1,0 +1,36 @@
+import typing
+
+import keyword_generation.handlers.handler_base
+
+"""
+                    "index": 0,
+                    "card": {
+                        "source": "include_card",
+                        "card-name": "IncludeCard"
+                    },
+                    "mixin": "IncludeCardMixin"
+"""
+class ExternalCardHandler(keyword_generation.handlers.handler_base.KeywordHandler):
+
+    def handle(self, kwd_data: typing.Dict[str, typing.Any], settings: typing.Dict[str, typing.Any]) -> None:
+        """Transform `kwd_data` based on `settings`."""
+        kwd_data["mixins"] = []
+        kwd_data["mixin_imports"] = []
+        for setting in settings:
+            card_name = setting["card"]["card-name"]
+            card_index = setting["index"]
+            card_source = setting["card"]["source"]
+            mixin_name = setting["mixin"]
+            kwd_data["mixins"].append(mixin_name)
+            kwd_data["mixin_imports"].append({
+                "source": card_source,
+                "names": [card_name, mixin_name]
+            })
+            external_card = kwd_data["cards"][card_index]
+            external_card["external"] = {
+                "name": card_name
+            }
+
+    def post_process(self, kwd_data: typing.Dict[str, typing.Any]) -> None:
+        """Run after all handlers have run."""
+        pass

--- a/codegen/keyword_generation/handlers/external_card.py
+++ b/codegen/keyword_generation/handlers/external_card.py
@@ -3,12 +3,13 @@ import typing
 import keyword_generation.handlers.handler_base
 
 """
-                    "index": 0,
-                    "card": {
-                        "source": "include_card",
-                        "card-name": "IncludeCard"
-                    },
-                    "mixin": "IncludeCardMixin"
+SCHEMA example:
+"index": 0,
+"card": {
+    "source": "include_card",
+    "card-name": "IncludeCard"
+},
+"mixin": "IncludeCardMixin"
 """
 class ExternalCardHandler(keyword_generation.handlers.handler_base.KeywordHandler):
 

--- a/codegen/manifest.json
+++ b/codegen/manifest.json
@@ -206,6 +206,20 @@
             ]
         }
     },
+    "INCLUDE_INCLUDE": {
+        "generation-options": {
+            "external-card-implementation": [
+                {
+                    "index": 0,
+                    "card": {
+                        "source": "include_card",
+                        "card-name": "IncludeCard"
+                    },
+                    "mixin": "IncludeCardMixin"
+                }
+            ]
+        }
+    },
     "PART_PART": {
         "generation-options": {
             "replace-card": [

--- a/codegen/templates/keyword.j2
+++ b/codegen/templates/keyword.j2
@@ -1,6 +1,12 @@
 {{license}}
 import typing
 {# TODO - only do this if there's a keyword without a default #}
+{% if keyword_data.mixin_imports %}
+{% for mixin_import in keyword_data.mixin_imports %}
+from ansys.dyna.core.lib.cards_.special.{{mixin_import.source}} import{% for name in mixin_import.names %}{{ ", " if not loop.first else " " }}{{name}}{% endfor %}
+{% endfor %}
+
+{% endif %}
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.config import use_lspp_defaults
 {% if keyword_data.duplicate %}
@@ -71,7 +77,18 @@ class {{card_set.name}}(Cards):
 
 {% endfor %}{# card_set in keyword_data.card_sets.sets #}
 {% endif %}{# keyword_data.card_sets #}
+{% if keyword_data.mixins %}
+class {{keyword_data.classname}}(
+    KeywordBase
+    {% if keyword_data.mixins %}
+{% for mixin in keyword_data.mixins %}
+    , {{mixin}}
+{% endfor %}
+    {% endif %}
+    ):
+{% else %}
 class {{keyword_data.classname}}(KeywordBase):
+{% endif %}
     """DYNA {{keyword_data.title}} keyword"""
 
     keyword = "{{keyword_data.keyword}}"

--- a/codegen/templates/keyword/card.j2
+++ b/codegen/templates/keyword/card.j2
@@ -72,6 +72,8 @@
                 None,
 {% endif %}
                 data = kwargs.get("{{card.overall_name}}")),
+{% elif card.external %}
+            {{card.external.name}}(**kwargs)
 {% else %}
             Card(
                 [

--- a/codegen/templates/keyword/card_properties.j2
+++ b/codegen/templates/keyword/card_properties.j2
@@ -34,6 +34,7 @@
         '''sets {{card.overall_name}} from the dataframe df'''
         self._cards[{{card.index}}].table = df
 
+{% elif card.external %}
 {% else %}
 {% for field in card.fields %}
 {% if field.used %}

--- a/doc/changelog/699.documentation.md
+++ b/doc/changelog/699.documentation.md
@@ -1,0 +1,1 @@
+fix: Support multiline include

--- a/doc/changelog/699.miscellaneous.md
+++ b/doc/changelog/699.miscellaneous.md
@@ -1,0 +1,1 @@
+Multiline include

--- a/doc/changelog/699.miscellaneous.md
+++ b/doc/changelog/699.miscellaneous.md
@@ -1,1 +1,0 @@
-Multiline include

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/include.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/include.py
@@ -20,11 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import typing
 from ansys.dyna.core.lib.cards_.special.include_card import IncludeCard, IncludeCardMixin
+from ansys.dyna.core.lib.card import Card, Field, Flag
+from ansys.dyna.core.lib.config import use_lspp_defaults
 from ansys.dyna.core.lib.keyword_base import KeywordBase
 
-
-class Include(KeywordBase, IncludeCardMixin):
+class Include(
+    KeywordBase
+    , IncludeCardMixin
+    ):
     """DYNA INCLUDE keyword"""
 
     keyword = "INCLUDE"
@@ -32,4 +37,7 @@ class Include(KeywordBase, IncludeCardMixin):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._cards = [IncludeCard(**kwargs)]
+        self._cards = [
+            IncludeCard(**kwargs)
+        ]
+

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/include.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/include.py
@@ -21,9 +21,9 @@
 # SOFTWARE.
 
 import typing
-from ansys.dyna.core.lib.card import Card, Field, Flag
-from ansys.dyna.core.lib.config import use_lspp_defaults
+from ansys.dyna.core.lib.cards_.special.include_card import IncludeCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
+
 
 class Include(KeywordBase):
     """DYNA INCLUDE keyword"""
@@ -33,19 +33,7 @@ class Include(KeywordBase):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._cards = [
-            Card(
-                [
-                    Field(
-                        "filename",
-                        str,
-                        0,
-                        80,
-                        kwargs.get("filename")
-                    ),
-                ],
-            ),
-        ]
+        self._cards = [IncludeCard(kwargs.get("filename"))]
 
     @property
     def filename(self) -> typing.Optional[str]:

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/include.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/include.py
@@ -20,12 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import typing
-from ansys.dyna.core.lib.cards_.special.include_card import IncludeCard
+from ansys.dyna.core.lib.cards_.special.include_card import IncludeCard, IncludeCardMixin
 from ansys.dyna.core.lib.keyword_base import KeywordBase
 
 
-class Include(KeywordBase):
+class Include(KeywordBase, IncludeCardMixin):
     """DYNA INCLUDE keyword"""
 
     keyword = "INCLUDE"
@@ -33,16 +32,4 @@ class Include(KeywordBase):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._cards = [IncludeCard(kwargs.get("filename"))]
-
-    @property
-    def filename(self) -> typing.Optional[str]:
-        """Get or set the File name of file to be included in this keyword file.
-        Maximum 80 charcters. If the STAMPED_PART option is active, this is the DYNAIN file containing the results from metal stamping.
-        """ # nopep8
-        return self._cards[0].get_value("filename")
-
-    @filename.setter
-    def filename(self, value: str) -> None:
-        self._cards[0].set_value("filename", value)
-
+        self._cards = [IncludeCard(**kwargs)]

--- a/src/ansys/dyna/core/lib/cards_/special/include_card.py
+++ b/src/ansys/dyna/core/lib/cards_/special/include_card.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2021 - 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import typing
+from ansys.dyna.core.lib.card import Card, Field
+from ansys.dyna.core.lib.io_utils import write_or_return
+from ansys.dyna.core.lib.field_writer import write_comment_line
+from ansys.dyna.core.lib.format_type import format_type
+from ansys.dyna.core.lib.kwd_line_formatter import read_line
+
+class IncludeCard(Card):
+    def __init__(self, filename: typing.Optional[str]):
+        super().__init__([
+            Field(
+                "filename",
+                str,
+                0,
+                80,
+                filename
+            ),
+        ],)
+
+    def _read_line(self, buf: typing.TextIO) -> str:
+        line, to_exit = read_line(buf)
+        if to_exit:
+            assert False, "*INCLUDE card missing filename"
+        return line
+
+    def read(self, buf: typing.TextIO, parameter_set) -> None:
+        """Reads the card data from an input text buffer."""
+        line = self._read_line(buf)
+        filename = line
+        if filename.endswith(" +"):
+            filename = filename[:-2]
+            line = self._read_line(buf)
+            filename += line
+            if filename.endswith(" +"):
+                filename = filename[:-2]
+                line = self._read_line(buf)
+                filename += line
+        else:
+            filename = filename.strip()
+        self.set_value("filename", filename)
+        return False
+
+    def write(
+        self, format: typing.Optional[format_type], buf: typing.Optional[typing.TextIO], comment: typing.Optional[bool]
+    ) -> typing.Union[str, None]:
+        if format == None:
+            format = self._format_type
+
+        def _write(buf: typing.TextIO):
+            if self._is_active():
+                if comment:
+                    write_comment_line(buf, self._fields, format)
+                    buf.write("\n")
+                filename = self.get_value("filename")
+                if len(filename) > 236:
+                    raise Exception("Maximum filename length is 236 characters")
+                if len(filename) <= 80:
+                    right_justified_filename= f"{{0:>80}}".format(filename)
+                    buf.write(right_justified_filename)
+                else:
+                    buf.write(filename[0:78])
+                    buf.write(" +\n")
+                    if len(filename) <= 158:
+                        buf.write(filename[78:])
+                    else:
+                        buf.write(filename[78:156])
+                        buf.write(" +\n")
+                        buf.write(filename[156:])
+
+        return write_or_return(buf, _write)

--- a/src/ansys/dyna/core/lib/cards_/special/include_card.py
+++ b/src/ansys/dyna/core/lib/cards_/special/include_card.py
@@ -21,27 +21,24 @@
 # SOFTWARE.
 
 import typing
+
 from ansys.dyna.core.lib.card import Card, Field
-from ansys.dyna.core.lib.io_utils import write_or_return
 from ansys.dyna.core.lib.field_writer import write_comment_line
 from ansys.dyna.core.lib.format_type import format_type
+from ansys.dyna.core.lib.io_utils import write_or_return
 from ansys.dyna.core.lib.kwd_line_formatter import read_line
-
 
 ## TODO codegen - add a codegen option to use a custom card
 #                 provide the class name, filename and mixin name
 
+
 class IncludeCard(Card):
     def __init__(self, **kwargs):
-        super().__init__([
-            Field(
-                "filename",
-                str,
-                0,
-                80,
-                kwargs.get("filename")
-            ),
-        ],)
+        super().__init__(
+            [
+                Field("filename", str, 0, 80, kwargs.get("filename")),
+            ],
+        )
 
     def _read_line(self, buf: typing.TextIO) -> str:
         line, to_exit = read_line(buf)
@@ -67,7 +64,10 @@ class IncludeCard(Card):
         return False
 
     def write(
-        self, format: typing.Optional[format_type], buf: typing.Optional[typing.TextIO], comment: typing.Optional[bool]
+        self,
+        format: typing.Optional[format_type] = None,
+        buf: typing.Optional[typing.TextIO] = None,
+        comment: typing.Optional[bool] = True,
     ) -> typing.Union[str, None]:
         if format == None:
             format = self._format_type
@@ -81,7 +81,7 @@ class IncludeCard(Card):
                 if len(filename) > 236:
                     raise Exception("Maximum filename length is 236 characters")
                 if len(filename) <= 80:
-                    right_justified_filename= f"{{0:<80}}".format(filename)
+                    right_justified_filename = f"{{0:<80}}".format(filename)
                     buf.write(right_justified_filename)
                 else:
                     buf.write(filename[0:78])
@@ -95,12 +95,14 @@ class IncludeCard(Card):
 
         return write_or_return(buf, _write)
 
-class IncludeCardMixin():
+
+class IncludeCardMixin:
     @property
     def filename(self) -> typing.Optional[str]:
         """Get or set the File name of file to be included in this keyword file.
-        Maximum 80 charcters. If the STAMPED_PART option is active, this is the DYNAIN file containing the results from metal stamping.
-        """ # nopep8
+        Maximum 80 characters. If the STAMPED_PART option is active, this is the
+        DYNAIN file containing the results from metal stamping.
+        """  # nopep8
         return self._cards[0].get_value("filename")
 
     @filename.setter

--- a/src/ansys/dyna/core/lib/cards_/special/include_card.py
+++ b/src/ansys/dyna/core/lib/cards_/special/include_card.py
@@ -81,7 +81,7 @@ class IncludeCard(Card):
                 if len(filename) > 236:
                     raise Exception("Maximum filename length is 236 characters")
                 if len(filename) <= 80:
-                    right_justified_filename= f"{{0:>80}}".format(filename)
+                    right_justified_filename= f"{{0:<80}}".format(filename)
                     buf.write(right_justified_filename)
                 else:
                     buf.write(filename[0:78])

--- a/src/ansys/dyna/core/lib/cards_/special/include_card.py
+++ b/src/ansys/dyna/core/lib/cards_/special/include_card.py
@@ -27,15 +27,19 @@ from ansys.dyna.core.lib.field_writer import write_comment_line
 from ansys.dyna.core.lib.format_type import format_type
 from ansys.dyna.core.lib.kwd_line_formatter import read_line
 
+
+## TODO codegen - add a codegen option to use a custom card
+#                 provide the class name, filename and mixin name
+
 class IncludeCard(Card):
-    def __init__(self, filename: typing.Optional[str]):
+    def __init__(self, **kwargs):
         super().__init__([
             Field(
                 "filename",
                 str,
                 0,
                 80,
-                filename
+                kwargs.get("filename")
             ),
         ],)
 
@@ -90,3 +94,15 @@ class IncludeCard(Card):
                         buf.write(filename[156:])
 
         return write_or_return(buf, _write)
+
+class IncludeCardMixin():
+    @property
+    def filename(self) -> typing.Optional[str]:
+        """Get or set the File name of file to be included in this keyword file.
+        Maximum 80 charcters. If the STAMPED_PART option is active, this is the DYNAIN file containing the results from metal stamping.
+        """ # nopep8
+        return self._cards[0].get_value("filename")
+
+    @filename.setter
+    def filename(self, value: str) -> None:
+        self._cards[0].set_value("filename", value)

--- a/src/ansys/dyna/core/lib/keyword_base.py
+++ b/src/ansys/dyna/core/lib/keyword_base.py
@@ -256,10 +256,14 @@ class KeywordBase(Cards):
         # maybe after the keyword but before any $#
         self._read_data(buf, parameters)
 
-    def loads(self, value: str, parameters: ParameterSet = None) -> None:
-        """Load the keyword from string."""
+    def loads(self, value: str, parameters: ParameterSet = None) -> typing.Any:
+        """Load the keyword from string.
+
+        Return `self` to support chaining
+        """
         # TODO - add a method to load from a buffer.
         s = io.StringIO()
         s.write(value)
         s.seek(0)
         self.read(s, parameters)
+        return self

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -902,6 +902,40 @@ def test_em_randles_batmac_rdltype(ref_string):
 
 
 @pytest.mark.keywords
+def test_multiline_include_keyword(ref_string):
+    i = kwd.Include()
+    filename = "a"*60 + ".k"
+    i.filename = filename
+    assert i.write() == ref_string.test_one_line_include1
+    assert kwd.Include().loads(ref_string.test_one_line_include1).filename == filename
+    filename = "a"*78 + ".k"
+    i.filename = filename
+    assert i.write() == ref_string.test_one_line_include2
+    assert kwd.Include().loads(ref_string.test_one_line_include2).filename == filename
+    filename = "a"*80 + ".k"
+    i.filename = filename
+    assert i.write() == ref_string.test_two_line_include1
+    assert kwd.Include().loads(ref_string.test_two_line_include1).filename == filename
+    filename = "a"*156 + ".k"
+    i.filename = filename
+    assert i.write() == ref_string.test_two_line_include2
+    assert kwd.Include().loads(ref_string.test_two_line_include2).filename == filename
+    filename = "a"*160 + ".k"
+    i.filename = filename
+    assert i.write() == ref_string.test_three_line_include1
+    assert kwd.Include().loads(ref_string.test_three_line_include1).filename == filename
+    filename = "a"*234 + ".k"
+    i.filename = filename
+    assert i.write() == ref_string.test_three_line_include2
+    assert kwd.Include().loads(ref_string.test_three_line_include2).filename == filename
+    with pytest.raises(Exception):
+        i.filename = "a"*300 + ".k"
+        i.write()
+
+
+
+
+@pytest.mark.keywords
 def test_em_randles_solid_rdltype(ref_string):
     s = kwd.EmRandlesSolid(rdltype=1)
     assert s.write() == ref_string.test_em_randles_solid_rdltype_0_1

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -903,9 +903,8 @@ def test_em_randles_batmac_rdltype(ref_string):
 
 @pytest.mark.keywords
 def test_multiline_include_keyword(ref_string):
-    i = kwd.Include()
     filename = "a"*60 + ".k"
-    i.filename = filename
+    i = kwd.Include(filename=filename)
     assert i.write() == ref_string.test_one_line_include1
     assert kwd.Include().loads(ref_string.test_one_line_include1).filename == filename
     filename = "a"*78 + ".k"

--- a/tests/testfiles/keywords/reference_string.py
+++ b/tests/testfiles/keywords/reference_string.py
@@ -100,6 +100,35 @@ $#     pid     ctype        np
 $#       x         y         z
                               """]
 
+test_one_line_include1 = """*INCLUDE
+$#                                                                      filename
+                  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.k"""
+
+test_one_line_include2 = """*INCLUDE
+$#                                                                      filename
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.k"""
+
+test_two_line_include1 = """*INCLUDE
+$#                                                                      filename
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+aa.k"""
+
+test_two_line_include2 = """*INCLUDE
+$#                                                                      filename
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.k"""
+
+test_three_line_include1 = """*INCLUDE
+$#                                                                      filename
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+aaaa.k"""
+
+test_three_line_include2 = """*INCLUDE
+$#                                                                      filename
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.k"""
 
 test_title_string = """*Keyword
 *DEFINE_CURVE_TITLE

--- a/tests/testfiles/keywords/reference_string.py
+++ b/tests/testfiles/keywords/reference_string.py
@@ -102,7 +102,7 @@ $#       x         y         z
 
 test_one_line_include1 = """*INCLUDE
 $#                                                                      filename
-                  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.k"""
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.k                  """
 
 test_one_line_include2 = """*INCLUDE
 $#                                                                      filename


### PR DESCRIPTION
Fixes #687 

introduces a new codegen option for an externally defined card. *INCLUDE's handling of a multiline field
is quite unique, so it makes more sense to define it manually and inject it into the code generation system.