### PR TITLE
feat: get by subkeyword and add transform links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,14 @@
 files: |
     (?x)(
+        ^codegen/ |
         ^src/ansys/ |
         ^examples |
         ^.github/
     )
 exclude: |
     (?x)^(
+        codegen/kwd.json|
+        codegen/additional-cards.json|
         doc/source/|
         src/ansys/dyna/core/pre/Server/|
         src/ansys/dyna/core/pre/doc/|

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -29,7 +29,7 @@ The class generator uses Jinja templates to generate three distinct things:
 The python classes are what users of PyDyna interact with directly. The import machinery produces
 `auto_keywords.py`, which contains a list of import statements that import classes from the
 Python files where they are defined. The keyword to type mapping produces a dictionary mapping the
-keyword name witht he python class that defines it.
+keyword name with the python class that defines it.
 
 The primary specification for keywords is found in `kwd.json`. It contains basic definitions
 for most keywords, including their cards and fields (which are defined by offset, name, default

--- a/codegen/generate.py
+++ b/codegen/generate.py
@@ -29,12 +29,9 @@ import shutil
 import typing
 
 from jinja2 import Environment, FileSystemLoader
-
 import keyword_generation.data_model as data_model
 from keyword_generation.generators import generate_class, generate_entrypoints
-
-from keyword_generation.utils import get_classname, get_this_folder, fix_keyword, handle_single_word_keyword
-
+from keyword_generation.utils import fix_keyword, get_classname, get_this_folder, handle_single_word_keyword
 
 SKIPPED_KEYWORDS = set(
     [
@@ -44,7 +41,7 @@ SKIPPED_KEYWORDS = set(
         "ELEMENT_SOLID (ten nodes format)",
         "ELEMENT_SOLID",
         "ELEMENT_SOLID_ORTHO (ten nodes format)",
-        "ELEMENT_SOLID_ORTHO"
+        "ELEMENT_SOLID_ORTHO",
         # issue #184 - this is not documented in the manual
         # "CONTROL_TIMESTEP",CONTROL_TIMESTEP is in the kwd.json now and should be generated issue #629
     ]
@@ -253,7 +250,7 @@ def parse_args():
         "--output",
         "-o",
         default="",
-        help="Output folder."
+        help="Output folder.",
         # help="Output folder. Defaults to the location of generated code in pydyna."
     )
     parser.add_argument(

--- a/codegen/keyword_generation/generators/class_generator.py
+++ b/codegen/keyword_generation/generators/class_generator.py
@@ -3,27 +3,24 @@ import os
 import typing
 
 from jinja2 import Environment
-
 import keyword_generation.data_model as data_model
-
-from keyword_generation.handlers.handler_base import KeywordHandler
+from keyword_generation.handlers.add_option import AddOptionHandler
+from keyword_generation.handlers.card_set import CardSetHandler
+from keyword_generation.handlers.conditional_card import ConditionalCardHandler
 from keyword_generation.handlers.external_card import ExternalCardHandler
+from keyword_generation.handlers.handler_base import KeywordHandler
+from keyword_generation.handlers.insert_card import InsertCardHandler
+from keyword_generation.handlers.override_field import OverrideFieldHandler
+from keyword_generation.handlers.override_subkeyword import OverrideSubkeywordHandler
+from keyword_generation.handlers.rename_property import RenamePropertyHandler
+from keyword_generation.handlers.reorder_card import ReorderCardHandler
+from keyword_generation.handlers.replace_card import ReplaceCardHandler
 from keyword_generation.handlers.series_card import SeriesCardHandler
 from keyword_generation.handlers.shared_field import SharedFieldHandler
+from keyword_generation.handlers.skip_card import SkipCardHandler
 from keyword_generation.handlers.table_card import TableCardHandler
 from keyword_generation.handlers.table_card_group import TableCardGroupHandler
-from keyword_generation.handlers.override_field import OverrideFieldHandler
-from keyword_generation.handlers.rename_property import RenamePropertyHandler
-from keyword_generation.handlers.conditional_card import ConditionalCardHandler
-from keyword_generation.handlers.add_option import AddOptionHandler
-from keyword_generation.handlers.override_subkeyword import OverrideSubkeywordHandler
-from keyword_generation.handlers.skip_card import SkipCardHandler
-from keyword_generation.handlers.insert_card import InsertCardHandler
-from keyword_generation.handlers.replace_card import ReplaceCardHandler
-from keyword_generation.handlers.card_set import CardSetHandler
-from keyword_generation.handlers.reorder_card import ReorderCardHandler
-
-from keyword_generation.utils import fix_keyword, get_license_header, get_classname, handle_single_word_keyword
+from keyword_generation.utils import fix_keyword, get_classname, get_license_header, handle_single_word_keyword
 
 
 def _get_source_keyword(keyword, settings):
@@ -272,6 +269,7 @@ def _handle_keyword_data(kwd_data, settings):
         handler.handle(kwd_data, handler_settings)
     _after_handle(kwd_data)
 
+
 def _add_define_transform_link_data(link_data: typing.List[typing.Dict], link_fields: typing.List[str]):
     transform_link_data = {
         "classname": "DefineTransformation",
@@ -283,13 +281,13 @@ def _add_define_transform_link_data(link_data: typing.List[typing.Dict], link_fi
     }
     link_data.append(transform_link_data)
 
+
 class LinkIdentity:
-    DEFINE_TRANSFORMATION=40
+    DEFINE_TRANSFORMATION = 40
+
 
 def _get_links(kwd_data) -> typing.Optional[typing.Dict]:
-    links = {
-        LinkIdentity.DEFINE_TRANSFORMATION: []
-    }
+    links = {LinkIdentity.DEFINE_TRANSFORMATION: []}
     has_link = False
     for card in kwd_data["cards"]:
         for field in _get_fields(card):
@@ -304,6 +302,7 @@ def _get_links(kwd_data) -> typing.Optional[typing.Dict]:
         return None
     return links
 
+
 def _add_links(kwd_data):
     """Add "links", or properties that link one keyword to another."""
     links = _get_links(kwd_data)
@@ -314,6 +313,7 @@ def _add_links(kwd_data):
         if link_type == LinkIdentity.DEFINE_TRANSFORMATION:
             _add_define_transform_link_data(link_data, link_fields)
     kwd_data["links"] = link_data
+
 
 def _get_keyword_data(keyword_name, keyword, settings):
     """Gets the keyword data dict from kwdm.  Transforms it

--- a/codegen/keyword_generation/generators/class_generator.py
+++ b/codegen/keyword_generation/generators/class_generator.py
@@ -273,7 +273,6 @@ def _handle_keyword_data(kwd_data, settings):
     _after_handle(kwd_data)
 
 def _add_define_transform_link_data(link_data: typing.List[typing.Dict], link_fields: typing.List[str]):
-    print(f"adding define transform links! {link_fields}")
     transform_link_data = {
         "classname": "DefineTransformation",
         "modulename": "define_transformation",
@@ -293,7 +292,7 @@ def _get_links(kwd_data) -> typing.Optional[typing.Dict]:
     }
     has_link = False
     for card in kwd_data["cards"]:
-        for field in card["fields"]:
+        for field in _get_fields(card):
             if "link" not in field:
                 continue
             link = field["link"]
@@ -314,7 +313,6 @@ def _add_links(kwd_data):
     for link_type, link_fields in links.items():
         if link_type == LinkIdentity.DEFINE_TRANSFORMATION:
             _add_define_transform_link_data(link_data, link_fields)
-    print(link_data)
     kwd_data["links"] = link_data
 
 def _get_keyword_data(keyword_name, keyword, settings):
@@ -360,8 +358,12 @@ def generate_class(env: Environment, lib_path: str, item: typing.Dict) -> None:
     keyword = item["name"]
     fixed_keyword = fix_keyword(keyword)
     classname = item["options"].get("classname", get_classname(fixed_keyword))
-    base_variable = _get_base_variable(classname, keyword, item["options"])
-    jinja_variable = _get_jinja_variable(base_variable)
-    filename = os.path.join(lib_path, "auto", fixed_keyword.lower() + ".py")
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(env.get_template("keyword.j2").render(**jinja_variable))
+    try:
+        base_variable = _get_base_variable(classname, keyword, item["options"])
+        jinja_variable = _get_jinja_variable(base_variable)
+        filename = os.path.join(lib_path, "auto", fixed_keyword.lower() + ".py")
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write(env.get_template("keyword.j2").render(**jinja_variable))
+    except Exception as e:
+        print(f"Failure in generating {classname}")
+        raise e

--- a/codegen/keyword_generation/generators/entrypoints_generator.py
+++ b/codegen/keyword_generation/generators/entrypoints_generator.py
@@ -3,8 +3,7 @@ import pathlib
 import typing
 
 from jinja2 import Environment
-
-from keyword_generation.utils import fix_keyword, get_license_header
+from keyword_generation.utils import get_license_header
 
 
 def generate_entrypoints(env: Environment, lib_path: str, keywords_list: typing.List[typing.Dict]) -> None:

--- a/codegen/keyword_generation/handlers/card_set.py
+++ b/codegen/keyword_generation/handlers/card_set.py
@@ -1,7 +1,6 @@
 import copy
 import typing
 
-from keyword_generation.data_model import get_card
 import keyword_generation.data_model as gen
 import keyword_generation.handlers.handler_base
 

--- a/codegen/keyword_generation/handlers/insert_card.py
+++ b/codegen/keyword_generation/handlers/insert_card.py
@@ -1,7 +1,7 @@
 import typing
 
-from keyword_generation.data_model import get_card
 import keyword_generation.data_model as gen
+from keyword_generation.data_model import get_card
 import keyword_generation.handlers.handler_base
 
 

--- a/codegen/keyword_generation/handlers/table_card_group.py
+++ b/codegen/keyword_generation/handlers/table_card_group.py
@@ -1,7 +1,7 @@
 import typing
 
-import keyword_generation.handlers.handler_base
 import keyword_generation.data_model as gen
+import keyword_generation.handlers.handler_base
 
 
 class TableCardGroupHandler(keyword_generation.handlers.handler_base.KeywordHandler):

--- a/codegen/templates/keyword.j2
+++ b/codegen/templates/keyword.j2
@@ -32,6 +32,9 @@ from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
 {% endif %}
 {% endif %}
 from ansys.dyna.core.lib.keyword_base import KeywordBase
+{% for link in keyword_data.links %}
+from ansys.dyna.core.keywords.keyword_classes.auto.{{link.modulename}} import {{link.classname}}
+{% endfor %}
 
 {% if keyword_data.card_sets %}
 {% for card_set in keyword_data.card_sets.sets %}
@@ -141,4 +144,7 @@ class {{keyword_data.classname}}(KeywordBase):
 {% include 'keyword/option_card_properties.j2' %}
 {% endfor %}{# option in keyword_data.options #}
 {% endif %}{# keyword_data.options #}
+{% with links = keyword_data.links %}
+{% include 'keyword/links.j2' %}
+{% endwith %}
 {% include 'keyword/alias.j2' %}

--- a/codegen/templates/keyword/links.j2
+++ b/codegen/templates/keyword/links.j2
@@ -1,0 +1,17 @@
+{% for link in links %}
+{% for field in link.fields %}
+    @property
+    def {{field}}_link(self) -> {{link.classname}}:
+        if self.deck is None:
+            return None
+        for kwd in deck.get_kwds_by_full_type("{{link.keyword_type}}", "{{link.keyword_subtype}}"):
+            if kwd.{{link.linkid}} == self.{{field}}:
+                return kwd
+        return None
+
+    @{{field}}_link.setter
+    def {{field}}_link(self, value: {{link.classname}}) -> None:
+        self.{{field}} = value.{{link.linkid}}
+
+{% endfor %}{# field in link.fields #}
+{% endfor %}{# link in links #}

--- a/codegen/templates/keyword/links.j2
+++ b/codegen/templates/keyword/links.j2
@@ -4,7 +4,7 @@
     def {{field}}_link(self) -> {{link.classname}}:
         if self.deck is None:
             return None
-        for kwd in deck.get_kwds_by_full_type("{{link.keyword_type}}", "{{link.keyword_subtype}}"):
+        for kwd in self.deck.get_kwds_by_full_type("{{link.keyword_type}}", "{{link.keyword_subtype}}"):
             if kwd.{{link.linkid}} == self.{{field}}:
                 return kwd
         return None

--- a/doc/changelog/735.test.md
+++ b/doc/changelog/735.test.md
@@ -1,0 +1,1 @@
+feat: get by subkeyword and add transform links

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/include_transform.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/include_transform.py
@@ -23,6 +23,7 @@
 import typing
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.keyword_base import KeywordBase
+from ansys.dyna.core.keywords.keyword_classes.auto.define_transformation import DefineTransformation
 
 class IncludeTransform(KeywordBase):
     """DYNA INCLUDE_TRANSFORM keyword"""
@@ -392,4 +393,17 @@ class IncludeTransform(KeywordBase):
     @tranid.setter
     def tranid(self, value: int) -> None:
         self._cards[4].set_value("tranid", value)
+
+    @property
+    def tranid_link(self) -> DefineTransformation:
+        if self.deck is None:
+            return None
+        for kwd in deck.get_kwds_by_full_type("DEFINE", "TRANSFORMATION"):
+            if kwd.tranid == self.tranid:
+                return kwd
+        return None
+
+    @tranid_link.setter
+    def tranid_link(self, value: DefineTransformation) -> None:
+        self.tranid = value.tranid
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/include_transform.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/include_transform.py
@@ -398,7 +398,7 @@ class IncludeTransform(KeywordBase):
     def tranid_link(self) -> DefineTransformation:
         if self.deck is None:
             return None
-        for kwd in deck.get_kwds_by_full_type("DEFINE", "TRANSFORMATION"):
+        for kwd in self.deck.get_kwds_by_full_type("DEFINE", "TRANSFORMATION"):
             if kwd.tranid == self.tranid:
                 return kwd
         return None

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/include_transform_binary.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/include_transform_binary.py
@@ -23,6 +23,7 @@
 import typing
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.keyword_base import KeywordBase
+from ansys.dyna.core.keywords.keyword_classes.auto.define_transformation import DefineTransformation
 
 class IncludeTransformBinary(KeywordBase):
     """DYNA INCLUDE_TRANSFORM_BINARY keyword"""
@@ -392,4 +393,17 @@ class IncludeTransformBinary(KeywordBase):
     @tranid.setter
     def tranid(self, value: int) -> None:
         self._cards[4].set_value("tranid", value)
+
+    @property
+    def tranid_link(self) -> DefineTransformation:
+        if self.deck is None:
+            return None
+        for kwd in self.deck.get_kwds_by_full_type("DEFINE", "TRANSFORMATION"):
+            if kwd.tranid == self.tranid:
+                return kwd
+        return None
+
+    @tranid_link.setter
+    def tranid_link(self, value: DefineTransformation) -> None:
+        self.tranid = value.tranid
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/node_transform.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/node_transform.py
@@ -23,6 +23,7 @@
 import typing
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.keyword_base import KeywordBase
+from ansys.dyna.core.keywords.keyword_classes.auto.define_transformation import DefineTransformation
 
 class NodeTransform(KeywordBase):
     """DYNA NODE_TRANSFORM keyword"""
@@ -94,4 +95,17 @@ class NodeTransform(KeywordBase):
         if value not in [0, 1, None]:
             raise Exception("""immed must be `None` or one of {0,1}""")
         self._cards[0].set_value("immed", value)
+
+    @property
+    def trsid_link(self) -> DefineTransformation:
+        if self.deck is None:
+            return None
+        for kwd in self.deck.get_kwds_by_full_type("DEFINE", "TRANSFORMATION"):
+            if kwd.tranid == self.trsid:
+                return kwd
+        return None
+
+    @trsid_link.setter
+    def trsid_link(self, value: DefineTransformation) -> None:
+        self.trsid = value.tranid
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/part_duplicate.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/part_duplicate.py
@@ -23,6 +23,7 @@
 import typing
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.keyword_base import KeywordBase
+from ansys.dyna.core.keywords.keyword_classes.auto.define_transformation import DefineTransformation
 
 class PartDuplicate(KeywordBase):
     """DYNA PART_DUPLICATE keyword"""
@@ -183,4 +184,17 @@ class PartDuplicate(KeywordBase):
     @zmin.setter
     def zmin(self, value: float) -> None:
         self._cards[0].set_value("zmin", value)
+
+    @property
+    def tranid_link(self) -> DefineTransformation:
+        if self.deck is None:
+            return None
+        for kwd in self.deck.get_kwds_by_full_type("DEFINE", "TRANSFORMATION"):
+            if kwd.tranid == self.tranid:
+                return kwd
+        return None
+
+    @tranid_link.setter
+    def tranid_link(self, value: DefineTransformation) -> None:
+        self.tranid = value.tranid
 

--- a/src/ansys/dyna/core/lib/deck.py
+++ b/src/ansys/dyna/core/lib/deck.py
@@ -227,6 +227,9 @@ class Deck:
                     keywords.extend(include_deck.all_keywords)
             else:
                 keywords.append(keyword)
+        for keyword in keywords:
+            if isinstance(keyword, KeywordBase):
+                keyword.deck = None
         return keywords
 
     def expand(self, cwd=None, recurse=True):

--- a/src/ansys/dyna/core/lib/deck.py
+++ b/src/ansys/dyna/core/lib/deck.py
@@ -433,7 +433,10 @@ class Deck:
 
         >>>deck.get_kwds_by_full_type("SECTION", "SHELL")
         """
-        return filter(lambda kwd: isinstance(kwd, KeywordBase) and kwd.keyword == str_type and kwd.subkeyword == str_subtype, self._keywords)
+        return filter(
+            lambda kwd: isinstance(kwd, KeywordBase) and kwd.keyword == str_type and kwd.subkeyword == str_subtype,
+            self._keywords,
+        )
 
     def get_section_by_id(self, id: int) -> typing.Optional[KeywordBase]:
         """Get the SECTION keyword in the collection for a given section ID.

--- a/src/ansys/dyna/core/lib/deck.py
+++ b/src/ansys/dyna/core/lib/deck.py
@@ -390,12 +390,12 @@ class Deck:
         self._check_unique("SECTION", "secid")
         self._check_valid()
 
-    def get_kwds_by_type(self, type: str) -> typing.Iterator[KeywordBase]:
+    def get_kwds_by_type(self, str_type: str) -> typing.Iterator[KeywordBase]:
         """Get all keywords for a given type.
 
         Parameters
         ----------
-        type : str
+        str_type : str
             Keyword type.
 
         Returns
@@ -404,11 +404,33 @@ class Deck:
 
         Examples
         --------
-        Get all SECTION keyword instances in the collection.
+        Get all *SECTION_* keywords in the deck.
 
         >>>deck.get_kwds_by_type("SECTION")
         """
-        return filter(lambda kwd: isinstance(kwd, KeywordBase) and kwd.keyword == type, self._keywords)
+        return filter(lambda kwd: isinstance(kwd, KeywordBase) and kwd.keyword == str_type, self._keywords)
+
+    def get_kwds_by_full_type(self, str_type: str, str_subtype: str) -> typing.Iterator[KeywordBase]:
+        """Get all keywords for a given full type.
+
+        Parameters
+        ----------
+        str_type : str
+            Keyword type.
+        str_subtype : str
+            Keyword subtype.
+
+        Returns
+        -------
+        typing.Iterator[KeywordBase]
+
+        Examples
+        --------
+        Get all *SECTION_SHELL keyword instances in the deck.
+
+        >>>deck.get_kwds_by_full_type("SECTION", "SHELL")
+        """
+        return filter(lambda kwd: isinstance(kwd, KeywordBase) and kwd.keyword == str_type and kwd.subkeyword == str_subtype, self._keywords)
 
     def get_section_by_id(self, id: int) -> typing.Optional[KeywordBase]:
         """Get the SECTION keyword in the collection for a given section ID.

--- a/src/ansys/dyna/core/lib/deck.py
+++ b/src/ansys/dyna/core/lib/deck.py
@@ -58,6 +58,9 @@ class Deck:
 
     def clear(self):
         """Clear all keywords from the deck."""
+        for keyword in self._keywords:
+            if isinstance(keyword, KeywordBase):
+                keyword.deck = None
         self._keywords = []
         self.comment_header = None
         self.title = None
@@ -101,8 +104,17 @@ class Deck:
         ), "Only keywords, encrypted keywords, or strings can be included in a deck."
         if isinstance(keyword, str):
             self._keywords.append(self._formatstring(keyword, check))
+        elif isinstance(keyword, KeywordBase):
+            keyword.deck = self
+            self._keywords.append(keyword)
         else:
             self._keywords.append(keyword)
+
+    def _remove_at(self, index: int) -> None:
+        kwd = self._keywords[index]
+        if isinstance(kwd, KeywordBase):
+            kwd.deck = None
+        del self._keywords[index]
 
     def remove(self, index: int | list[int]) -> None:
         """Remove a keyword from the collection by index.
@@ -113,10 +125,10 @@ class Deck:
         """
         try:
             if isinstance(index, int):
-                del self._keywords[index]
+                self._remove_at(index)
             elif isinstance(index, list):
                 for i in sorted(index, reverse=True):
-                    del self._keywords[i]
+                    self._remove_at(i)
             else:
                 raise TypeError("Input must be an integer or a list of integers.")
         except IndexError:

--- a/src/ansys/dyna/core/lib/keyword_base.py
+++ b/src/ansys/dyna/core/lib/keyword_base.py
@@ -46,7 +46,7 @@ class KeywordBase(Cards):
         super().__init__(self)
         self.user_comment = kwargs.get("user_comment", "")
         self._format_type: format_type = kwargs.get("format", format_type.default)
-        self._deck: "Deck" = kwargs.get("deck", None)
+        self._deck = None
 
     @property
     def deck(self) -> typing.Optional["Deck"]:
@@ -58,6 +58,12 @@ class KeywordBase(Cards):
     def deck(self, deck: "Deck") -> None:
         """Get the deck that this keyword is associated to.
         """
+        if deck is None:
+            self._deck = None
+            return
+
+        if self._deck is not None:
+            raise Exception("This keyword is already associated with a deck!")
         self._deck = deck
 
     @property

--- a/src/ansys/dyna/core/lib/keyword_base.py
+++ b/src/ansys/dyna/core/lib/keyword_base.py
@@ -29,6 +29,9 @@ from ansys.dyna.core.lib.cards import Cards
 from ansys.dyna.core.lib.format_type import format_type
 from ansys.dyna.core.lib.parameters import ParameterSet
 
+# protected due to circular import
+if typing.TYPE_CHECKING:
+    from ansys.dyna.core.lib.deck import Deck
 
 class KeywordBase(Cards):
     """Base class for all keywords.
@@ -43,6 +46,19 @@ class KeywordBase(Cards):
         super().__init__(self)
         self.user_comment = kwargs.get("user_comment", "")
         self._format_type: format_type = kwargs.get("format", format_type.default)
+        self._deck: "Deck" = kwargs.get("deck", None)
+
+    @property
+    def deck(self) -> typing.Optional["Deck"]:
+        """Get the deck that this keyword is associated to.
+        """
+        return self._deck
+
+    @deck.setter
+    def deck(self, deck: "Deck") -> None:
+        """Get the deck that this keyword is associated to.
+        """
+        self._deck = deck
 
     @property
     def format(self) -> format_type:

--- a/src/ansys/dyna/core/lib/keyword_base.py
+++ b/src/ansys/dyna/core/lib/keyword_base.py
@@ -33,6 +33,7 @@ from ansys.dyna.core.lib.parameters import ParameterSet
 if typing.TYPE_CHECKING:
     from ansys.dyna.core.lib.deck import Deck
 
+
 class KeywordBase(Cards):
     """Base class for all keywords.
 
@@ -50,14 +51,12 @@ class KeywordBase(Cards):
 
     @property
     def deck(self) -> typing.Optional["Deck"]:
-        """Get the deck that this keyword is associated to.
-        """
+        """Get the deck that this keyword is associated to."""
         return self._deck
 
     @deck.setter
     def deck(self, deck: "Deck") -> None:
-        """Get the deck that this keyword is associated to.
-        """
+        """Get the deck that this keyword is associated to."""
         if deck is None:
             self._deck = None
             return

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -223,6 +223,7 @@ def test_kwdeck_basic_001(file_utils):
     deck = Deck()
     deck.title = "Basic 001"
     curve1 = kwd.DefineCurve()
+    assert curve1.deck is None
     curve1.user_comment = "My first curve"
     curve2 = kwd.DefineCurve(offa=2.0)
     curve2.curves = pd.DataFrame({"a1": [1, 3, 5], "o1": [2, 4, 6]})
@@ -253,6 +254,7 @@ def test_kwdeck_basic_001(file_utils):
             boundary3,
         ]
     )
+    assert curve1.deck == deck
     deck_string = deck.write()
     file_utils.compare_string_with_file(deck_string, "test.k")
 
@@ -369,6 +371,21 @@ def test_deck_read_long_deck_standard_keyword():
     assert deck.format == format_type.long
     assert len(deck.keywords) == 1
     assert deck.keywords[0].area == 1.0
+
+
+@pytest.mark.keywords
+def test_deck_links():
+    deck = Deck()
+    deck.append(kwd.DefineTransformation(tranid=10, option="POINT", a1=1, a2=2.0, a3=0.0, a4=1.0))
+    i_c = kwd.IncludeTransform(tranid=10)
+    deck.append(i_c)
+    xforms = i_c.tranid_link.transforms
+    assert len(xforms) == 1
+    assert xforms["option"][0] == "POINT"
+    assert xforms["a1"][0] == 1
+    assert xforms["a2"][0] == 2.0
+    assert xforms["a3"][0] == 0.0
+    assert xforms["a4"][0] == 1.0
 
 
 @pytest.mark.keywords


### PR DESCRIPTION
Fixes #606 

Also introduces the concept of "links".  Some keywords refer to each other using ids like "lcid, "pid", "tranid", etc.

The keyword class should have a way of getting the keyword associated with that ID in the same deck without having to search through all keywords of the deck.

I added this to the code generation system (the concept of "link" already existed in kwd.json with some predefined link types, there 40 meant DEFINE_TRANSFORMATION)

