### PR TITLE
fix: pass **args to plotter object

### DIFF
--- a/doc/changelog/755.miscellaneous.md
+++ b/doc/changelog/755.miscellaneous.md
@@ -1,0 +1,1 @@
+fix pass **args to plotter object

--- a/examples/John_Reid_Pipe/plot_john_pipe.py
+++ b/examples/John_Reid_Pipe/plot_john_pipe.py
@@ -162,7 +162,7 @@ def run_post(filepath):
 
 shutil.copy(mesh_file, os.path.join(rundir.name, mesh_file_name))
 deck = write_deck(os.path.join(rundir.name, dynafile))
-deck.plot(cwd=rundir.name)
+deck.plot(cwd=rundir.name, show_edges=True)
 
 ###############################################################################
 # Run the Dyna solver

--- a/src/ansys/dyna/core/lib/deck_plotter.py
+++ b/src/ansys/dyna/core/lib/deck_plotter.py
@@ -344,4 +344,4 @@ def get_polydata(deck: Deck, cwd=None):
 def plot_deck(deck, **args):
     """Plot the deck."""
     plot_data = get_polydata(deck, args.pop("cwd", ""))
-    return plot_data.plot()
+    return plot_data.plot(**args)


### PR DESCRIPTION
**args are now passed to plotter e.g.  show_edges=True to show the mesh. The argument is added to the plot_john_pipe example to show the capability
![image](https://github.com/user-attachments/assets/efac01a5-8993-426f-aef3-03e061725e36)
