### PR TITLE
feat: Dataframe typehints

### DIFF
--- a/codegen/templates/keyword.j2
+++ b/codegen/templates/keyword.j2
@@ -4,6 +4,13 @@
 import dataclasses
 {% endif %}
 import typing
+{% if keyword_data.duplicate %}
+import pandas as pd
+
+{% elif keyword_data.duplicate_group %}
+import pandas as pd
+
+{% endif %}
 {# TODO - only do this if there's a keyword without a default #}
 {% if keyword_data.mixin_imports %}
 {% for mixin_import in keyword_data.mixin_imports %}

--- a/codegen/templates/keyword/card_properties.j2
+++ b/codegen/templates/keyword/card_properties.j2
@@ -1,11 +1,11 @@
 {% if card.duplicate %}
     @property
-    def {{card.duplicate.name}}(self):
+    def {{card.duplicate.name}}(self) -> pd.DataFrame:
         """Get the table of {{card.duplicate.name}}."""
         return self._cards[{{card.index}}].table
 
     @{{card.duplicate.name}}.setter
-    def {{card.duplicate.name}}(self, df):
+    def {{card.duplicate.name}}(self, df: pd.DataFrame):
         """Set {{card.duplicate.name}} from the dataframe df"""
         self._cards[{{card.index}}].table = df
 
@@ -31,12 +31,12 @@
 
 {% elif card.duplicate_group %}
     @property
-    def {{card.overall_name}}(self):
+    def {{card.overall_name}}(self) -> pd.DataFrame:
         """Gets the full table of {{card.overall_name}}."""
         return self._cards[{{card.index}}].table
 
     @{{card.overall_name}}.setter
-    def {{card.overall_name}}(self, df):
+    def {{card.overall_name}}(self, df: pd.DataFrame):
         """sets {{card.overall_name}} from the dataframe df."""
         self._cards[{{card.index}}].table = df
 

--- a/doc/changelog/921.added.md
+++ b/doc/changelog/921.added.md
@@ -1,0 +1,1 @@
+Dataframe typehints

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/boundary_spc_node.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/boundary_spc_node.py
@@ -22,6 +22,8 @@
 
 """Module providing the BoundarySpcNode class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -83,12 +85,12 @@ class BoundarySpcNode(KeywordBase):
         ]
 
     @property
-    def nodes(self):
+    def nodes(self) -> pd.DataFrame:
         """Get the table of nodes."""
         return self._cards[0].table
 
     @nodes.setter
-    def nodes(self, df):
+    def nodes(self, df: pd.DataFrame):
         """Set nodes from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/constrained_adaptivity.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/constrained_adaptivity.py
@@ -22,6 +22,8 @@
 
 """Module providing the ConstrainedAdaptivity class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -49,12 +51,12 @@ class ConstrainedAdaptivity(KeywordBase):
         ]
 
     @property
-    def constrains(self):
+    def constrains(self) -> pd.DataFrame:
         """Get the table of constrains."""
         return self._cards[0].table
 
     @constrains.setter
-    def constrains(self, df):
+    def constrains(self, df: pd.DataFrame):
         """Set constrains from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/constrained_nodal_rigid_body.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/constrained_nodal_rigid_body.py
@@ -22,6 +22,8 @@
 
 """Module providing the ConstrainedNodalRigidBody class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card_group import TableCardGroup
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -115,12 +117,12 @@ class ConstrainedNodalRigidBody(KeywordBase):
         ]
 
     @property
-    def constrained_nodal_rigid_bodies(self):
+    def constrained_nodal_rigid_bodies(self) -> pd.DataFrame:
         """Gets the full table of constrained_nodal_rigid_bodies."""
         return self._cards[0].table
 
     @constrained_nodal_rigid_bodies.setter
-    def constrained_nodal_rigid_bodies(self, df):
+    def constrained_nodal_rigid_bodies(self, df: pd.DataFrame):
         """sets constrained_nodal_rigid_bodies from the dataframe df."""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/constrained_rigid_bodies.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/constrained_rigid_bodies.py
@@ -22,6 +22,8 @@
 
 """Module providing the ConstrainedRigidBodies class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -49,12 +51,12 @@ class ConstrainedRigidBodies(KeywordBase):
         ]
 
     @property
-    def pairs(self):
+    def pairs(self) -> pd.DataFrame:
         """Get the table of pairs."""
         return self._cards[0].table
 
     @pairs.setter
-    def pairs(self, df):
+    def pairs(self, df: pd.DataFrame):
         """Set pairs from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/control_mpp_decomposition_transformation.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/control_mpp_decomposition_transformation.py
@@ -22,6 +22,8 @@
 
 """Module providing the ControlMppDecompositionTransformation class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card_group import TableCardGroup
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -116,12 +118,12 @@ class ControlMppDecompositionTransformation(KeywordBase):
         ]
 
     @property
-    def transformation(self):
+    def transformation(self) -> pd.DataFrame:
         """Gets the full table of transformation."""
         return self._cards[0].table
 
     @transformation.setter
-    def transformation(self, df):
+    def transformation(self, df: pd.DataFrame):
         """sets transformation from the dataframe df."""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/define_curve.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/define_curve.py
@@ -22,6 +22,8 @@
 
 """Module providing the DefineCurve class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -239,12 +241,12 @@ class DefineCurve(KeywordBase):
         self._cards[0].set_value("lcint", value)
 
     @property
-    def curves(self):
+    def curves(self) -> pd.DataFrame:
         """Get the table of curves."""
         return self._cards[1].table
 
     @curves.setter
-    def curves(self, df):
+    def curves(self, df: pd.DataFrame):
         """Set curves from the dataframe df"""
         self._cards[1].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/define_sd_orientation.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/define_sd_orientation.py
@@ -22,6 +22,8 @@
 
 """Module providing the DefineSdOrientation class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -75,12 +77,12 @@ class DefineSdOrientation(KeywordBase):
         ]
 
     @property
-    def vectors(self):
+    def vectors(self) -> pd.DataFrame:
         """Get the table of vectors."""
         return self._cards[0].table
 
     @vectors.setter
-    def vectors(self, df):
+    def vectors(self, df: pd.DataFrame):
         """Set vectors from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/define_transformation.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/define_transformation.py
@@ -22,6 +22,8 @@
 
 """Module providing the DefineTransformation class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -98,12 +100,12 @@ class DefineTransformation(KeywordBase):
         self._cards[0].set_value("tranid", value)
 
     @property
-    def transforms(self):
+    def transforms(self) -> pd.DataFrame:
         """Get the table of transforms."""
         return self._cards[1].table
 
     @transforms.setter
-    def transforms(self, df):
+    def transforms(self, df: pd.DataFrame):
         """Set transforms from the dataframe df"""
         self._cards[1].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/element_beam.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/element_beam.py
@@ -22,6 +22,8 @@
 
 """Module providing the ElementBeam class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -56,12 +58,12 @@ class ElementBeam(KeywordBase):
         ]
 
     @property
-    def elements(self):
+    def elements(self) -> pd.DataFrame:
         """Get the table of elements."""
         return self._cards[0].table
 
     @elements.setter
-    def elements(self, df):
+    def elements(self, df: pd.DataFrame):
         """Set elements from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/element_discrete.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/element_discrete.py
@@ -22,6 +22,8 @@
 
 """Module providing the ElementDiscrete class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -54,12 +56,12 @@ class ElementDiscrete(KeywordBase):
         ]
 
     @property
-    def elements(self):
+    def elements(self) -> pd.DataFrame:
         """Get the table of elements."""
         return self._cards[0].table
 
     @elements.setter
-    def elements(self, df):
+    def elements(self, df: pd.DataFrame):
         """Set elements from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/element_shell.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/element_shell.py
@@ -22,6 +22,8 @@
 
 """Module providing the ElementShell class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -56,12 +58,12 @@ class ElementShell(KeywordBase):
         ]
 
     @property
-    def elements(self):
+    def elements(self) -> pd.DataFrame:
         """Get the table of elements."""
         return self._cards[0].table
 
     @elements.setter
-    def elements(self, df):
+    def elements(self, df: pd.DataFrame):
         """Set elements from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/element_shell_thickness.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/element_shell_thickness.py
@@ -22,6 +22,8 @@
 
 """Module providing the ElementShellThickness class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card_group import TableCardGroup
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -174,12 +176,12 @@ class ElementShellThickness(KeywordBase):
         ]
 
     @property
-    def elements(self):
+    def elements(self) -> pd.DataFrame:
         """Gets the full table of elements."""
         return self._cards[0].table
 
     @elements.setter
-    def elements(self, df):
+    def elements(self, df: pd.DataFrame):
         """sets elements from the dataframe df."""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_boundary_freeslip.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_boundary_freeslip.py
@@ -22,6 +22,8 @@
 
 """Module providing the IcfdBoundaryFreeslip class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -47,12 +49,12 @@ class IcfdBoundaryFreeslip(KeywordBase):
         ]
 
     @property
-    def boundaries(self):
+    def boundaries(self) -> pd.DataFrame:
         """Get the table of boundaries."""
         return self._cards[0].table
 
     @boundaries.setter
-    def boundaries(self, df):
+    def boundaries(self, df: pd.DataFrame):
         """Set boundaries from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_boundary_fsi.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_boundary_fsi.py
@@ -22,6 +22,8 @@
 
 """Module providing the IcfdBoundaryFsi class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -47,12 +49,12 @@ class IcfdBoundaryFsi(KeywordBase):
         ]
 
     @property
-    def boundaries(self):
+    def boundaries(self) -> pd.DataFrame:
         """Get the table of boundaries."""
         return self._cards[0].table
 
     @boundaries.setter
-    def boundaries(self, df):
+    def boundaries(self, df: pd.DataFrame):
         """Set boundaries from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_boundary_fsi_exclude.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_boundary_fsi_exclude.py
@@ -22,6 +22,8 @@
 
 """Module providing the IcfdBoundaryFsiExclude class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -47,12 +49,12 @@ class IcfdBoundaryFsiExclude(KeywordBase):
         ]
 
     @property
-    def boundaries(self):
+    def boundaries(self) -> pd.DataFrame:
         """Get the table of boundaries."""
         return self._cards[0].table
 
     @boundaries.setter
-    def boundaries(self, df):
+    def boundaries(self, df: pd.DataFrame):
         """Set boundaries from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_boundary_nonslip.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_boundary_nonslip.py
@@ -22,6 +22,8 @@
 
 """Module providing the IcfdBoundaryNonslip class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -47,12 +49,12 @@ class IcfdBoundaryNonslip(KeywordBase):
         ]
 
     @property
-    def boundaries(self):
+    def boundaries(self) -> pd.DataFrame:
         """Get the table of boundaries."""
         return self._cards[0].table
 
     @boundaries.setter
-    def boundaries(self, df):
+    def boundaries(self, df: pd.DataFrame):
         """Set boundaries from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_boundary_prescribed_pre.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_boundary_prescribed_pre.py
@@ -22,6 +22,8 @@
 
 """Module providing the IcfdBoundaryPrescribedPre class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -51,12 +53,12 @@ class IcfdBoundaryPrescribedPre(KeywordBase):
         ]
 
     @property
-    def boundaries(self):
+    def boundaries(self) -> pd.DataFrame:
         """Get the table of boundaries."""
         return self._cards[0].table
 
     @boundaries.setter
-    def boundaries(self, df):
+    def boundaries(self, df: pd.DataFrame):
         """Set boundaries from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_database_flux.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_database_flux.py
@@ -22,6 +22,8 @@
 
 """Module providing the IcfdDatabaseFlux class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -48,12 +50,12 @@ class IcfdDatabaseFlux(KeywordBase):
         ]
 
     @property
-    def boundaries(self):
+    def boundaries(self) -> pd.DataFrame:
         """Get the table of boundaries."""
         return self._cards[0].table
 
     @boundaries.setter
-    def boundaries(self, df):
+    def boundaries(self, df: pd.DataFrame):
         """Set boundaries from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_part.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_part.py
@@ -22,6 +22,8 @@
 
 """Module providing the IcfdPart class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -71,12 +73,12 @@ class IcfdPart(KeywordBase):
         ]
 
     @property
-    def nodes(self):
+    def nodes(self) -> pd.DataFrame:
         """Get the table of nodes."""
         return self._cards[0].table
 
     @nodes.setter
-    def nodes(self, df):
+    def nodes(self, df: pd.DataFrame):
         """Set nodes from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_part_vol.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/icfd_part_vol.py
@@ -22,6 +22,8 @@
 
 """Module providing the IcfdPartVol class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -134,12 +136,12 @@ class IcfdPartVol(KeywordBase):
         self._cards[0].set_value("mid", value)
 
     @property
-    def nodes(self):
+    def nodes(self) -> pd.DataFrame:
         """Get the table of nodes."""
         return self._cards[1].table
 
     @nodes.setter
-    def nodes(self, df):
+    def nodes(self, df: pd.DataFrame):
         """Set nodes from the dataframe df"""
         self._cards[1].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/initial_strain_shell.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/initial_strain_shell.py
@@ -22,6 +22,8 @@
 
 """Module providing the InitialStrainShell class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.card_set import CardSet
@@ -180,12 +182,12 @@ class InitialStrainShellCardSet(Cards):
         self._cards[0].set_value("ilocal", value)
 
     @property
-    def strains(self):
+    def strains(self) -> pd.DataFrame:
         """Get the table of strains."""
         return self._cards[1].table
 
     @strains.setter
-    def strains(self, df):
+    def strains(self, df: pd.DataFrame):
         """Set strains from the dataframe df"""
         self._cards[1].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/initial_temperature_node.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/initial_temperature_node.py
@@ -22,6 +22,8 @@
 
 """Module providing the InitialTemperatureNode class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -49,12 +51,12 @@ class InitialTemperatureNode(KeywordBase):
         ]
 
     @property
-    def nodes(self):
+    def nodes(self) -> pd.DataFrame:
         """Get the table of nodes."""
         return self._cards[0].table
 
     @nodes.setter
-    def nodes(self, df):
+    def nodes(self, df: pd.DataFrame):
         """Set nodes from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/initial_temperature_set.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/initial_temperature_set.py
@@ -22,6 +22,8 @@
 
 """Module providing the InitialTemperatureSet class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -49,12 +51,12 @@ class InitialTemperatureSet(KeywordBase):
         ]
 
     @property
-    def sets(self):
+    def sets(self) -> pd.DataFrame:
         """Get the table of sets."""
         return self._cards[0].table
 
     @sets.setter
-    def sets(self, df):
+    def sets(self, df: pd.DataFrame):
         """Set sets from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/load_node_point.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/load_node_point.py
@@ -22,6 +22,8 @@
 
 """Module providing the LoadNodePoint class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -54,12 +56,12 @@ class LoadNodePoint(KeywordBase):
         ]
 
     @property
-    def nodes(self):
+    def nodes(self) -> pd.DataFrame:
         """Get the table of nodes."""
         return self._cards[0].table
 
     @nodes.setter
-    def nodes(self, df):
+    def nodes(self, df: pd.DataFrame):
         """Set nodes from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_077_h.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_077_h.py
@@ -22,6 +22,8 @@
 
 """Module providing the Mat077H class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -540,12 +542,12 @@ class Mat077H(KeywordBase):
         self._cards[3].set_value("therml", value)
 
     @property
-    def constants(self):
+    def constants(self) -> pd.DataFrame:
         """Get the table of constants."""
         return self._cards[4].table
 
     @constants.setter
-    def constants(self, df):
+    def constants(self, df: pd.DataFrame):
         """Set constants from the dataframe df"""
         self._cards[4].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_077_o.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_077_o.py
@@ -22,6 +22,8 @@
 
 """Module providing the Mat077O class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -707,12 +709,12 @@ class Mat077O(KeywordBase):
         self._cards[4].set_value("alpha8", value)
 
     @property
-    def constants(self):
+    def constants(self) -> pd.DataFrame:
         """Get the table of constants."""
         return self._cards[5].table
 
     @constants.setter
-    def constants(self, df):
+    def constants(self, df: pd.DataFrame):
         """Set constants from the dataframe df"""
         self._cards[5].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_124.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_124.py
@@ -22,6 +22,8 @@
 
 """Module providing the Mat124 class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -527,12 +529,12 @@ class Mat124(KeywordBase):
         self._cards[3].set_value("k", value)
 
     @property
-    def constants(self):
+    def constants(self) -> pd.DataFrame:
         """Get the table of constants."""
         return self._cards[4].table
 
     @constants.setter
-    def constants(self, df):
+    def constants(self, df: pd.DataFrame):
         """Set constants from the dataframe df"""
         self._cards[4].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_181.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_181.py
@@ -22,6 +22,8 @@
 
 """Module providing the Mat181 class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -519,12 +521,12 @@ class Mat181(KeywordBase):
         self._cards[2].set_value("hisout", value)
 
     @property
-    def constants(self):
+    def constants(self) -> pd.DataFrame:
         """Get the table of constants."""
         return self._cards[3].table
 
     @constants.setter
-    def constants(self, df):
+    def constants(self, df: pd.DataFrame):
         """Set constants from the dataframe df"""
         self._cards[3].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_196.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_196.py
@@ -22,6 +22,8 @@
 
 """Module providing the Mat196 class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card_group import TableCardGroup
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -247,12 +249,12 @@ class Mat196(KeywordBase):
         self._cards[0].set_value("dospot", value)
 
     @property
-    def springs(self):
+    def springs(self) -> pd.DataFrame:
         """Gets the full table of springs."""
         return self._cards[1].table
 
     @springs.setter
-    def springs(self, df):
+    def springs(self, df: pd.DataFrame):
         """sets springs from the dataframe df."""
         self._cards[1].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_295.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_295.py
@@ -22,6 +22,8 @@
 
 """Module providing the Mat295 class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card_group import TableCardGroup
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -1265,12 +1267,12 @@ class Mat295(KeywordBase):
         self._cards[6].set_value("nf", value)
 
     @property
-    def anisotropic_settings(self):
+    def anisotropic_settings(self) -> pd.DataFrame:
         """Gets the full table of anisotropic_settings."""
         return self._cards[7].table
 
     @anisotropic_settings.setter
-    def anisotropic_settings(self, df):
+    def anisotropic_settings(self, df: pd.DataFrame):
         """sets anisotropic_settings from the dataframe df."""
         self._cards[7].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_simplified_rubber_foam_log_log_interpolation.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_simplified_rubber_foam_log_log_interpolation.py
@@ -22,6 +22,8 @@
 
 """Module providing the MatSimplifiedRubberFoamLogLogInterpolation class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -519,12 +521,12 @@ class MatSimplifiedRubberFoamLogLogInterpolation(KeywordBase):
         self._cards[2].set_value("hisout", value)
 
     @property
-    def constants(self):
+    def constants(self) -> pd.DataFrame:
         """Get the table of constants."""
         return self._cards[3].table
 
     @constants.setter
-    def constants(self, df):
+    def constants(self, df: pd.DataFrame):
         """Set constants from the dataframe df"""
         self._cards[3].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_simplified_rubber_foam_log_log_interpolation_with_failure.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_simplified_rubber_foam_log_log_interpolation_with_failure.py
@@ -22,6 +22,8 @@
 
 """Module providing the MatSimplifiedRubberFoamLogLogInterpolationWithFailure class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -597,12 +599,12 @@ class MatSimplifiedRubberFoamLogLogInterpolationWithFailure(KeywordBase):
         self._cards[3].set_value("hisout", value)
 
     @property
-    def constants(self):
+    def constants(self) -> pd.DataFrame:
         """Get the table of constants."""
         return self._cards[4].table
 
     @constants.setter
-    def constants(self, df):
+    def constants(self, df: pd.DataFrame):
         """Set constants from the dataframe df"""
         self._cards[4].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_simplified_rubber_foam_with_failure.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_simplified_rubber_foam_with_failure.py
@@ -22,6 +22,8 @@
 
 """Module providing the MatSimplifiedRubberFoamWithFailure class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -597,12 +599,12 @@ class MatSimplifiedRubberFoamWithFailure(KeywordBase):
         self._cards[3].set_value("hisout", value)
 
     @property
-    def constants(self):
+    def constants(self) -> pd.DataFrame:
         """Get the table of constants."""
         return self._cards[4].table
 
     @constants.setter
-    def constants(self, df):
+    def constants(self, df: pd.DataFrame):
         """Set constants from the dataframe df"""
         self._cards[4].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_simplified_rubber_foam_with_failure_log_log_interpolation.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mat_simplified_rubber_foam_with_failure_log_log_interpolation.py
@@ -22,6 +22,8 @@
 
 """Module providing the MatSimplifiedRubberFoamWithFailureLogLogInterpolation class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -597,12 +599,12 @@ class MatSimplifiedRubberFoamWithFailureLogLogInterpolation(KeywordBase):
         self._cards[3].set_value("hisout", value)
 
     @property
-    def constants(self):
+    def constants(self) -> pd.DataFrame:
         """Get the table of constants."""
         return self._cards[4].table
 
     @constants.setter
-    def constants(self, df):
+    def constants(self, df: pd.DataFrame):
         """Set constants from the dataframe df"""
         self._cards[4].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mesh_node.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mesh_node.py
@@ -22,6 +22,8 @@
 
 """Module providing the MeshNode class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -50,12 +52,12 @@ class MeshNode(KeywordBase):
         ]
 
     @property
-    def nodes(self):
+    def nodes(self) -> pd.DataFrame:
         """Get the table of nodes."""
         return self._cards[0].table
 
     @nodes.setter
-    def nodes(self, df):
+    def nodes(self, df: pd.DataFrame):
         """Set nodes from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mesh_surface_element.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mesh_surface_element.py
@@ -22,6 +22,8 @@
 
 """Module providing the MeshSurfaceElement class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -52,12 +54,12 @@ class MeshSurfaceElement(KeywordBase):
         ]
 
     @property
-    def elements(self):
+    def elements(self) -> pd.DataFrame:
         """Get the table of elements."""
         return self._cards[0].table
 
     @elements.setter
-    def elements(self, df):
+    def elements(self, df: pd.DataFrame):
         """Set elements from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/mesh_surface_node.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/mesh_surface_node.py
@@ -22,6 +22,8 @@
 
 """Module providing the MeshSurfaceNode class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -50,12 +52,12 @@ class MeshSurfaceNode(KeywordBase):
         ]
 
     @property
-    def nodes(self):
+    def nodes(self) -> pd.DataFrame:
         """Get the table of nodes."""
         return self._cards[0].table
 
     @nodes.setter
-    def nodes(self, df):
+    def nodes(self, df: pd.DataFrame):
         """Set nodes from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/node.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/node.py
@@ -22,6 +22,8 @@
 
 """Module providing the Node class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -52,12 +54,12 @@ class Node(KeywordBase):
         ]
 
     @property
-    def nodes(self):
+    def nodes(self) -> pd.DataFrame:
         """Get the table of nodes."""
         return self._cards[0].table
 
     @nodes.setter
-    def nodes(self, df):
+    def nodes(self, df: pd.DataFrame):
         """Set nodes from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/parameter_expression.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/parameter_expression.py
@@ -22,6 +22,8 @@
 
 """Module providing the ParameterExpression class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -48,12 +50,12 @@ class ParameterExpression(KeywordBase):
         ]
 
     @property
-    def parameters(self):
+    def parameters(self) -> pd.DataFrame:
         """Get the table of parameters."""
         return self._cards[0].table
 
     @parameters.setter
-    def parameters(self, df):
+    def parameters(self, df: pd.DataFrame):
         """Set parameters from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/parameter_expression_local.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/parameter_expression_local.py
@@ -22,6 +22,8 @@
 
 """Module providing the ParameterExpressionLocal class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -48,12 +50,12 @@ class ParameterExpressionLocal(KeywordBase):
         ]
 
     @property
-    def parameters(self):
+    def parameters(self) -> pd.DataFrame:
         """Get the table of parameters."""
         return self._cards[0].table
 
     @parameters.setter
-    def parameters(self, df):
+    def parameters(self, df: pd.DataFrame):
         """Set parameters from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/parameter_local.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/parameter_local.py
@@ -22,6 +22,8 @@
 
 """Module providing the ParameterLocal class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.keyword_base import KeywordBase
@@ -54,12 +56,12 @@ class ParameterLocal(KeywordBase):
         ]
 
     @property
-    def parameters(self):
+    def parameters(self) -> pd.DataFrame:
         """Get the table of parameters."""
         return self._cards[0].table
 
     @parameters.setter
-    def parameters(self, df):
+    def parameters(self, df: pd.DataFrame):
         """Set parameters from the dataframe df"""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/part.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/part.py
@@ -22,11 +22,11 @@
 
 """Module providing the Part class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card_group import TableCardGroup
 from ansys.dyna.core.lib.keyword_base import KeywordBase
-
-import pandas as pd
 
 class Part(KeywordBase):
     """DYNA PART keyword"""

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/part.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/part.py
@@ -26,6 +26,8 @@ from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card_group import TableCardGroup
 from ansys.dyna.core.lib.keyword_base import KeywordBase
 
+import pandas as pd
+
 class Part(KeywordBase):
     """DYNA PART keyword"""
 
@@ -109,12 +111,12 @@ class Part(KeywordBase):
         ]
 
     @property
-    def parts(self):
+    def parts(self) -> pd.DataFrame:
         """Gets the full table of parts."""
         return self._cards[0].table
 
     @parts.setter
-    def parts(self, df):
+    def parts(self, df: pd.DataFrame):
         """sets parts from the dataframe df."""
         self._cards[0].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/section_shell.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/section_shell.py
@@ -22,6 +22,8 @@
 
 """Module providing the SectionShell class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.series_card import SeriesCard
@@ -660,12 +662,12 @@ class SectionShell(KeywordBase):
         self._cards[3].set_value("iloc", value)
 
     @property
-    def integration_points(self):
+    def integration_points(self) -> pd.DataFrame:
         """Get the table of integration_points."""
         return self._cards[4].table
 
     @integration_points.setter
-    def integration_points(self, df):
+    def integration_points(self, df: pd.DataFrame):
         """Set integration_points from the dataframe df"""
         self._cards[4].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/section_solid.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/section_solid.py
@@ -22,6 +22,8 @@
 
 """Module providing the SectionSolid class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.series_card import SeriesCard
@@ -381,12 +383,12 @@ class SectionSolid(KeywordBase):
         self._cards[1].set_value("nhsv", value)
 
     @property
-    def integration_points(self):
+    def integration_points(self) -> pd.DataFrame:
         """Get the table of integration_points."""
         return self._cards[2].table
 
     @integration_points.setter
-    def integration_points(self, df):
+    def integration_points(self, df: pd.DataFrame):
         """Set integration_points from the dataframe df"""
         self._cards[2].table = df
 

--- a/src/ansys/dyna/core/keywords/keyword_classes/auto/set_segment.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/auto/set_segment.py
@@ -22,6 +22,8 @@
 
 """Module providing the SetSegment class."""
 import typing
+import pandas as pd
+
 from ansys.dyna.core.lib.card import Card, Field, Flag
 from ansys.dyna.core.lib.table_card import TableCard
 from ansys.dyna.core.lib.option_card import OptionCardSet, OptionSpec
@@ -224,12 +226,12 @@ class SetSegment(KeywordBase):
         self._cards[0].set_value("its", value)
 
     @property
-    def segments(self):
+    def segments(self) -> pd.DataFrame:
         """Get the table of segments."""
         return self._cards[1].table
 
     @segments.setter
-    def segments(self, df):
+    def segments(self, df: pd.DataFrame):
         """Set segments from the dataframe df"""
         self._cards[1].table = df
 

--- a/src/ansys/dyna/core/lib/card_set.py
+++ b/src/ansys/dyna/core/lib/card_set.py
@@ -67,7 +67,7 @@ class CardSet(CardInterface):
     def _items(self, value: typing.List[Cards]) -> None:
         self._base_items = value
 
-    def _initialize(self):
+    def _initialize(self) -> None:
         if self._initialized:
             return
         if self._bounded and self.active:

--- a/src/ansys/dyna/core/lib/card_set.py
+++ b/src/ansys/dyna/core/lib/card_set.py
@@ -78,7 +78,7 @@ class CardSet(CardInterface):
         self._initialize()
 
     @property
-    def option_specs(self):
+    def option_specs(self) -> typing.List[OptionSpec]:
         return self._option_specs
 
     @property

--- a/src/ansys/dyna/core/lib/table_card.py
+++ b/src/ansys/dyna/core/lib/table_card.py
@@ -125,7 +125,7 @@ class TableCard(Card):
         self._initialized = True
 
     @property
-    def table(self):
+    def table(self) -> pd.DataFrame:
         if not self._initialized:
             self._initialize()
         return self._table
@@ -147,7 +147,7 @@ class TableCard(Card):
         self._initialized = True
 
     @property
-    def format(self):
+    def format(self) -> format_type:
         return self._format_type
 
     @format.setter

--- a/src/ansys/dyna/core/lib/table_card_group.py
+++ b/src/ansys/dyna/core/lib/table_card_group.py
@@ -80,7 +80,7 @@ class TableCardGroup(CardInterface):
         self._initialized = True
 
     @property
-    def table(self):
+    def table(self) -> pd.DataFrame:
         self._initialize()
         return self._table
 


### PR DESCRIPTION
There's no autocomplete in an IDE like vscode when writing `Part().parts["pid"][0]` because the `parts` property does not declare its return type. This PR fixes that by adding typhints to the generated files (as well as some of the library)