### PR TITLE
fix: support multiline `*COMMENT` keyword

### DIFF
--- a/codegen/manifest.json
+++ b/codegen/manifest.json
@@ -862,6 +862,9 @@
         },
         "comment": "card 6 (mat146_discrete_card) is skipped because of the condition for mat 146 - which we cannot easily check here. Maybe that can be handled in a subclass. card 7 (discrete_dof_card) is skipped because its a duplicate of card 4. card 9 (duplicate_inertia_card) is skipped because its a duplicate of card 2"
     },
+    "COMMENT": {
+        "action": "manual"
+    },
     "DEFINE_FUNCTION": {
         "action": "manual"
     },

--- a/doc/changelog/1226.fixed.md
+++ b/doc/changelog/1226.fixed.md
@@ -1,0 +1,1 @@
+Support multiline \`*COMMENT\` keyword

--- a/src/ansys/dyna/core/keywords/keyword_classes/manual/comment.py
+++ b/src/ansys/dyna/core/keywords/keyword_classes/manual/comment.py
@@ -19,49 +19,39 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Module for manual keyword overrides."""
+"""Module to define *COMMENT keyword with multiline support."""
 
-# Manual keyword overrides - wrapped in try/except to support subset generation
-try:
-    from .manual.comment import Comment  # noqa: F401
-except ImportError:
-    pass
+import typing
 
-try:
-    from .manual.define_function import DefineFunction  # noqa: F401
-except ImportError:
-    pass
+from ansys.dyna.core.lib.keyword_base import KeywordBase
+from ansys.dyna.core.lib.text_card import TextCard
 
-try:
-    from .manual.define_table import DefineTable  # noqa: F401
-except ImportError:
-    pass
 
-try:
-    from .manual.element_solid import ElementSolid  # noqa: F401
-except ImportError:
-    pass
+class Comment(KeywordBase):
+    """DYNA COMMENT keyword.
 
-try:
-    from .manual.element_solid_ortho import ElementSolidOrtho  # noqa: F401
-except ImportError:
-    pass
+    Supports multiline free-form text comments.
+    """
 
-try:
-    from .manual.mat_295 import Mat295, MatAnisotropicHyperelastic  # noqa: F401
-except ImportError:
-    pass
+    keyword = "COMMENT"
+    subkeyword = "COMMENT"
 
-try:
-    from .manual.section_tshell import SectionTShell  # noqa: F401
-except ImportError:
-    pass
+    def __init__(self, **kwargs):
+        """Initialize Comment keyword."""
+        super().__init__(**kwargs)
+        self._cards = [
+            TextCard("comment", kwargs.get("comment")),
+        ]
 
-try:
-    from .manual.parameter_expression import (  # noqa: F401
-        ParameterExpression,
-        ParameterExpressionLocal,
-        ParameterExpressionNoecho,
-    )
-except ImportError:
-    pass
+    @property
+    def comment(self) -> typing.Optional[str]:
+        """Get or set the comment text.
+
+        The comment can span multiple lines. Lines are separated by newline characters.
+        """
+        return self._cards[0].value
+
+    @comment.setter
+    def comment(self, value: str) -> None:
+        """Set the comment text."""
+        self._cards[0].value = value

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Tests for *COMMENT multiline support.""
+
+import pytest
+
+from ansys.dyna.core import Deck
+from ansys.dyna.core import keywords as kwd
+
+
+# -- import tests -----------------------------------------------------------
+
+def test_comment_import_multiline_all_lines_present():
+    """Importing a deck with a 3-line *COMMENT must preserve all three lines.
+
+    Reproduces: https://github.com/ansys/pydyna/issues/1211
+    Bug: only Line1 was stored; Line2 and Line3 were silently dropped.
+    """
+    deck_string = "*KEYWORD\n*COMMENT\nLine1\nLine2\nLine3\n*END"
+    deck = Deck()
+    deck.loads(deck_string)
+
+    comments = [k for k in deck.keywords if isinstance(k, kwd.Comment)]
+    assert len(comments) == 1, "Expected exactly one *COMMENT keyword"
+
+    text = comments[0].comment
+    assert text == "Line1\nLine2\nLine3", (
+        f"Expected all three lines, got: {text!r}"
+    )
+
+
+def test_comment_import_multiline_round_trip(ref_string):
+    """A round-trip (load -> write) must reproduce all comment lines.
+
+    Reproduces: https://github.com/ansys/pydyna/issues/1211
+    """
+    deck_string = "*KEYWORD\n*COMMENT\nLine1\nLine2\nLine3\n*END"
+    deck = Deck()
+    deck.loads(deck_string)
+
+    output = deck.write()
+    assert output.strip() == ref_string.test_comment_deck_roundtrip.strip(), (
+        f"Round-trip deck output does not match reference.\nGot:\n{output}"
+    )
+
+
+# -- write / property tests -------------------------------------------------
+
+def test_comment_write_multiline_not_truncated(ref_string):
+    """Setting a multiline comment must not truncate at 170 characters.
+
+    Reproduces: https://github.com/ansys/pydyna/issues/1211
+    Bug: the 20-line string "\\n".join(["0123456789"]*20) was cropped to ~170 chars
+    (8 full lines + a partial "012" line).
+    """
+    multiline = "\n".join(["0123456789"] * 20)
+    k = kwd.Comment(comment=multiline)
+    output = k.write()
+
+    assert output.strip() == ref_string.test_comment_multiline_20_write.strip(), (
+        f"Write output does not match reference.\nGot:\n{output}"
+    )
+
+
+def test_comment_write_three_lines(ref_string):
+    """Write output for a 3-line comment must match the reference string."""
+    k = kwd.Comment(comment="Line1\nLine2\nLine3")
+    output = k.write()
+
+    assert output.strip() == ref_string.test_comment_multiline_write.strip(), (
+        f"Write output does not match reference.\nGot:\n{output}"
+    )
+
+
+def test_comment_property_round_trip():
+    """The comment property getter must return exactly what was set."""
+    text = "First line\nSecond line\nThird line"
+    k = kwd.Comment(comment=text)
+    assert k.comment == text, "comment property did not round-trip correctly"
+
+
+def test_comment_single_line_unchanged():
+    """A single-line comment must still work as before."""
+    k = kwd.Comment(comment="This is a single line comment")
+    output = k.write()
+    assert "This is a single line comment" in output

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Tests for *COMMENT multiline support.""
+"""Tests for *COMMENT multiline support."""
 
 import pytest
 
@@ -32,7 +32,6 @@ from ansys.dyna.core import keywords as kwd
 def test_comment_import_multiline_all_lines_present():
     """Importing a deck with a 3-line *COMMENT must preserve all three lines.
 
-    Reproduces: https://github.com/ansys/pydyna/issues/1211
     Bug: only Line1 was stored; Line2 and Line3 were silently dropped.
     """
     deck_string = "*KEYWORD\n*COMMENT\nLine1\nLine2\nLine3\n*END"
@@ -49,10 +48,7 @@ def test_comment_import_multiline_all_lines_present():
 
 
 def test_comment_import_multiline_round_trip(ref_string):
-    """A round-trip (load -> write) must reproduce all comment lines.
-
-    Reproduces: https://github.com/ansys/pydyna/issues/1211
-    """
+    """A round-trip (load -> write) must reproduce all comment lines."""
     deck_string = "*KEYWORD\n*COMMENT\nLine1\nLine2\nLine3\n*END"
     deck = Deck()
     deck.loads(deck_string)
@@ -68,7 +64,6 @@ def test_comment_import_multiline_round_trip(ref_string):
 def test_comment_write_multiline_not_truncated(ref_string):
     """Setting a multiline comment must not truncate at 170 characters.
 
-    Reproduces: https://github.com/ansys/pydyna/issues/1211
     Bug: the 20-line string "\\n".join(["0123456789"]*20) was cropped to ~170 chars
     (8 full lines + a partial "012" line).
     """

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -21,80 +21,71 @@
 # SOFTWARE.
 """Tests for *COMMENT multiline support."""
 
-import pytest
+import pathlib
 
 from ansys.dyna.core import Deck
 from ansys.dyna.core import keywords as kwd
 
+_ASSETS = pathlib.Path(__file__).parent / "testfiles" / "keywords"
 
-# -- import tests -----------------------------------------------------------
 
 def test_comment_import_multiline_all_lines_present():
-    """Importing a deck with a 3-line *COMMENT must preserve all three lines.
-
-    Bug: only Line1 was stored; Line2 and Line3 were silently dropped.
-    """
+    """Importing a deck with a 3-line *COMMENT preserves all three lines."""
     deck_string = "*KEYWORD\n*COMMENT\nLine1\nLine2\nLine3\n*END"
     deck = Deck()
     deck.loads(deck_string)
 
     comments = [k for k in deck.keywords if isinstance(k, kwd.Comment)]
-    assert len(comments) == 1, "Expected exactly one *COMMENT keyword"
+    assert len(comments) == 1
+    assert comments[0].comment == "Line1\nLine2\nLine3"
 
-    text = comments[0].comment
-    assert text == "Line1\nLine2\nLine3", (
-        f"Expected all three lines, got: {text!r}"
-    )
+
+def test_comment_import_from_file():
+    """Importing a *COMMENT from a .k file preserves all lines."""
+    deck = Deck()
+    deck.import_file(str(_ASSETS / "test_multiline_comment.k"))
+
+    comments = [kw for kw in deck.keywords if isinstance(kw, kwd.Comment)]
+    assert len(comments) == 1
+    assert comments[0].comment == "Line1\nLine2\nLine3"
 
 
 def test_comment_import_multiline_round_trip(ref_string):
-    """A round-trip (load -> write) must reproduce all comment lines."""
+    """A round-trip (load -> write) reproduces all comment lines."""
     deck_string = "*KEYWORD\n*COMMENT\nLine1\nLine2\nLine3\n*END"
     deck = Deck()
     deck.loads(deck_string)
 
     output = deck.write()
-    assert output.strip() == ref_string.test_comment_deck_roundtrip.strip(), (
-        f"Round-trip deck output does not match reference.\nGot:\n{output}"
-    )
+    assert output.strip() == ref_string.test_comment_deck_roundtrip.strip()
 
-
-# -- write / property tests -------------------------------------------------
 
 def test_comment_write_multiline_not_truncated(ref_string):
-    """Setting a multiline comment must not truncate at 170 characters.
-
-    Bug: the 20-line string "\\n".join(["0123456789"]*20) was cropped to ~170 chars
-    (8 full lines + a partial "012" line).
-    """
+    """Writing a 20-line comment produces all 20 lines without truncation."""
     multiline = "\n".join(["0123456789"] * 20)
     k = kwd.Comment(comment=multiline)
     output = k.write()
 
-    assert output.strip() == ref_string.test_comment_multiline_20_write.strip(), (
-        f"Write output does not match reference.\nGot:\n{output}"
-    )
+    assert output.strip() == ref_string.test_comment_multiline_20_write.strip()
 
 
 def test_comment_write_three_lines(ref_string):
-    """Write output for a 3-line comment must match the reference string."""
+    """Write output for a 3-line comment matches the reference string."""
     k = kwd.Comment(comment="Line1\nLine2\nLine3")
     output = k.write()
 
-    assert output.strip() == ref_string.test_comment_multiline_write.strip(), (
-        f"Write output does not match reference.\nGot:\n{output}"
-    )
+    assert output.strip() == ref_string.test_comment_multiline_write.strip()
 
 
 def test_comment_property_round_trip():
-    """The comment property getter must return exactly what was set."""
+    """The comment property getter returns exactly what was set."""
     text = "First line\nSecond line\nThird line"
     k = kwd.Comment(comment=text)
-    assert k.comment == text, "comment property did not round-trip correctly"
+    assert k.comment == text
 
 
 def test_comment_single_line_unchanged():
-    """A single-line comment must still work as before."""
+    """A single-line comment writes correctly."""
     k = kwd.Comment(comment="This is a single line comment")
     output = k.write()
     assert "This is a single line comment" in output

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -41,13 +41,46 @@ def test_comment_import_multiline_all_lines_present():
 
 
 def test_comment_import_from_file():
-    """Importing a *COMMENT from a .k file preserves all lines."""
+    """Importing *COMMENT blocks from a .k file preserves all lines of each block."""
     deck = Deck()
     deck.import_file(str(_ASSETS / "test_multiline_comment.k"))
 
     comments = [kw for kw in deck.keywords if isinstance(kw, kwd.Comment)]
-    assert len(comments) == 1
-    assert comments[0].comment == "Line1\nLine2\nLine3"
+    assert len(comments) == 3
+    assert comments[0].comment == (
+        "DISABLED: self-contact removed for this load case\n"
+        "Re-enable if buckling is observed"
+    )
+    assert comments[1].comment == (
+        "Contact definition: impactor vs plate\n"
+        "Automatic surface-to-surface, friction 0.2"
+    )
+    assert comments[2].comment == (
+        "Segment sets for contact surfaces\n"
+        "Surface 1: impactor face (nodes 2842-2846)\n"
+        "Surface 2: plate top face (nodes 626-3242)"
+    )
+
+
+def test_comment_disabled_contact_keyword_order():
+    """A *COMMENT immediately before a contact keyword does not consume it.
+
+    The keyword following a *COMMENT must appear in the deck as a parsed keyword,
+    not as part of the comment text.
+    """
+    deck = Deck()
+    deck.import_file(str(_ASSETS / "test_multiline_comment.k"))
+
+    types = [type(kw).__name__ for kw in deck.keywords]
+    assert "Comment" in types
+    # Both contacts are parsed — the *COMMENT before each did not swallow them
+    assert types.count("ContactAutomaticSingleSurface") == 1
+    assert types.count("ContactAutomaticSurfaceToSurface") == 1
+    # Keyword order: disabled comment → single-surface contact → annotation comment → s2s contact
+    comment_idx = [i for i, t in enumerate(types) if t == "Comment"]
+    single_surface_idx = types.index("ContactAutomaticSingleSurface")
+    s2s_idx = types.index("ContactAutomaticSurfaceToSurface")
+    assert comment_idx[0] < single_surface_idx < comment_idx[1] < s2s_idx
 
 
 def test_comment_import_multiline_round_trip(ref_string):

--- a/tests/testfiles/keywords/reference_string.py
+++ b/tests/testfiles/keywords/reference_string.py
@@ -1754,7 +1754,7 @@ test_element_mass_part_set_with_mwd = """*ELEMENT_MASS_PART_SET
 $#   pid         addmass         finmass    lcid     mwd
     1463         0.00491             0.0       0       1"""
 
-# Reference strings for *COMMENT multiline tests (issue #1211)
+# Reference strings for *COMMENT multiline tests
 test_comment_multiline_write = """*COMMENT
 $#                                                                       comment
 Line1

--- a/tests/testfiles/keywords/reference_string.py
+++ b/tests/testfiles/keywords/reference_string.py
@@ -1753,3 +1753,24 @@ $#   pid         addmass         finmass    lcid
 test_element_mass_part_set_with_mwd = """*ELEMENT_MASS_PART_SET
 $#   pid         addmass         finmass    lcid     mwd
     1463         0.00491             0.0       0       1"""
+
+# Reference strings for *COMMENT multiline tests (issue #1211)
+test_comment_multiline_write = """*COMMENT
+$#                                                                       comment
+Line1
+Line2
+Line3"""
+
+test_comment_multiline_20_write = (
+    "*COMMENT\n$#                                                                       comment\n"
+    + "\n".join(["0123456789"] * 20)
+)
+
+test_comment_deck_roundtrip = """$
+*KEYWORD
+*COMMENT
+$#                                                                       comment
+Line1
+Line2
+Line3
+*END"""

--- a/tests/testfiles/keywords/test_multiline_comment.k
+++ b/tests/testfiles/keywords/test_multiline_comment.k
@@ -1,0 +1,6 @@
+*KEYWORD
+*COMMENT
+Line1
+Line2
+Line3
+*END

--- a/tests/testfiles/keywords/test_multiline_comment.k
+++ b/tests/testfiles/keywords/test_multiline_comment.k
@@ -1,6 +1,37 @@
 *KEYWORD
 *COMMENT
-Line1
-Line2
-Line3
+DISABLED: self-contact removed for this load case
+Re-enable if buckling is observed
+*CONTACT_AUTOMATIC_SINGLE_SURFACE
+$#     ssid      msid    sstyp    mstyp    sboxid    mboxid       spr       mpr
+         0         0         0         0         0         0         0         0
+$#       fs        fd        dc        vc       vdc    penchk        bt        dt
+      0.00      0.00      0.00      0.00      0.00         0     0.000  1.00e+20
+*COMMENT
+Contact definition: impactor vs plate
+Automatic surface-to-surface, friction 0.2
+*CONTACT_AUTOMATIC_SURFACE_TO_SURFACE
+$#    surfa     surfb  surfatyp  surfbtyp   saboxid   sbboxid      sapr      sbpr
+         1         2         0         0         0         0         0         0
+$#       fs        fd        dc        vc       vdc    penchk        bt        dt
+      0.20      0.00      0.00      0.00      0.00         0     0.000  1.00e+20
+$#     sfsa      sfsb      sast      sbst     sfsat     sfsbt       fsf       vsf
+      1.00      1.00      0.00      0.00      1.00      1.00      1.00      1.00
+$#     soft    sofscl    lcidab    maxpar     sbopt     depth     bsort    frcfrq
+         2      0.10         0     1.025      0.00         2        10         1
+*COMMENT
+Segment sets for contact surfaces
+Surface 1: impactor face (nodes 2842-2846)
+Surface 2: plate top face (nodes 626-3242)
+*SET_SEGMENT
+$#      sid       da1       da2       da3       da4    solver
+         1     0.000     0.000     0.000     0.000      MECH
+$#       n1        n2        n3        n4        a1        a2        a3        a4
+      2842       626      3232      3242     0.000     0.000     0.000     0.000
+      2846      2842       627      2843     0.000     0.000     0.000     0.000
+*SET_SEGMENT
+$#      sid       da1       da2       da3       da4    solver
+         2     0.000     0.000     0.000     0.000      MECH
+$#       n1        n2        n3        n4        a1        a2        a3        a4
+       626      2842      3242       627     0.000     0.000     0.000     0.000
 *END


### PR DESCRIPTION
fix #1211 

### Problem
The *COMMENT keyword in LS-DYNA allows an arbitrary number of free-form text lines, terminated by the next keyword line starting with *. PyDyna's implementation  was auto-generated from the keyword schema as a standard fixed-width card with a single 80-character field. 

This produced two bugs:

1. **Import truncation.** When reading a deck with a multiline *COMMENT, only the first line was captured; every subsequent line was silently discarded.
2.  **Write truncation.** When the `comment` property was set to a multiline string, the output was cropped at 80 characters (approximately 8 lines of 10-character content), matching the single field width.Import truncation. When reading a deck with a multiline *COMMENT, only the first line was captured; every subsequent line was silently discarded.

A common real-world pattern is placing a `*COMMENT` immediately before a contact keyword to annotate or temporarily disable it. Decks using this pattern were parsed incorrectly after importing.

since `table-card` is used fixed-width card data organised into rows and columns. They are designed for repeating tabular records (element tables, material property rows) and for cards that are conditionally present based on field values. Neither mechanism provides the ability to read an unbounded sequence of free-form text lines until a keyword boundary is encountered.


### Fix

`*COMMENT` is changed from an auto-generated keyword to a manual implementation, following the same pattern already used by `*DEFINE_FUNCTION.`