### PR TITLE
feat: replace custom `DownloadManager` implementation

### DIFF
--- a/benchmarks/bench_general.py
+++ b/benchmarks/bench_general.py
@@ -30,7 +30,7 @@ import numpy as np
 import pandas as pd
 
 from ansys.dyna.core import Deck, keywords as kwd
-from ansys.dyna.core.utils.download_utilities import DownloadManager
+from ansys.dyna.core.utils.download_utilities import download_manager
 
 
 def _gen_nodes(count):
@@ -111,15 +111,14 @@ def perf_002() -> io.StringIO:
 
 def perf_003() -> None:
     """Test loading the yaris deck - this takes about 7 seconds now."""
-    path = ("ls-dyna", "yaris_stat_shock_absorber_loading")
+    path = "ls-dyna/yaris_stat_shock_absorber_loading"
 
-    downloader = DownloadManager()
-    downloader.download_file("fixed_ground.k", *path)
-    downloader.download_file("implicit_control_cards_R9.k", *path)
-    downloader.download_file("YarisD_V2g_shock_abs_load_01.k", *path)
-    downloader.download_file("YarisD_V2g_shock_abs_load_01_nodes.k", *path)
+    download_manager.download_file("fixed_ground.k", path)
+    download_manager.download_file("implicit_control_cards_R9.k", path)
+    download_manager.download_file("YarisD_V2g_shock_abs_load_01.k", path)
+    download_manager.download_file("YarisD_V2g_shock_abs_load_01_nodes.k", path)
     main_filename = "000_yaris_stat_shock_absorber_loading_01.k"
-    output = downloader.download_file(main_filename, *path)
+    output = download_manager.download_file(main_filename, path)
     folder = os.path.dirname(output)
     deck = Deck()
     fname = os.path.join(folder, main_filename)

--- a/doc/changelog/1229.added.md
+++ b/doc/changelog/1229.added.md
@@ -1,0 +1,1 @@
+Replace custom \`DownloadManager\` implementation

--- a/examples/Buckling_Beer_Can/plot_beercan.py
+++ b/examples/Buckling_Beer_Can/plot_beercan.py
@@ -49,12 +49,12 @@ import pandas as pd
 
 from ansys.dyna.core import Deck, keywords as kwd
 from ansys.dyna.core.run import MemoryUnit, MpiOption, run_dyna
-from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, DownloadManager
+from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, download_manager
 
 rundir = tempfile.TemporaryDirectory()
 mesh_file_name = "mesh.k"
-mesh_file = DownloadManager().download_file(
-    mesh_file_name, "ls-dyna", "Buckling_Beer_Can", destination=os.path.join(EXAMPLES_PATH, "Buckling_Beer_Can")
+mesh_file = download_manager.download_file(
+    mesh_file_name, "ls-dyna/Buckling_Beer_Can", destination=os.path.join(EXAMPLES_PATH, "Buckling_Beer_Can")
 )
 
 dynafile = "beer_can.k"

--- a/examples/John_Reid_Pendulum/plot_john_reid_pendulum.py
+++ b/examples/John_Reid_Pendulum/plot_john_reid_pendulum.py
@@ -45,11 +45,11 @@ import pandas as pd
 
 from ansys.dyna.core import Deck, keywords as kwd
 from ansys.dyna.core.run import run_dyna
-from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, DownloadManager
+from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, download_manager
 
 mesh_file_name = "nodes.k"
-mesh_file = DownloadManager().download_file(
-    mesh_file_name, "ls-dyna", "John_Reid_Pendulum", destination=os.path.join(EXAMPLES_PATH, "John_Reid_Pendulum")
+mesh_file = download_manager.download_file(
+    mesh_file_name, "ls-dyna/John_Reid_Pendulum", destination=os.path.join(EXAMPLES_PATH, "John_Reid_Pendulum")
 )
 
 rundir = tempfile.TemporaryDirectory()

--- a/examples/John_Reid_Pipe/plot_john_pipe.py
+++ b/examples/John_Reid_Pipe/plot_john_pipe.py
@@ -45,11 +45,11 @@ import pandas as pd
 
 from ansys.dyna.core import Deck, keywords as kwd
 from ansys.dyna.core.run import run_dyna
-from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, DownloadManager
+from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, download_manager
 
 mesh_file_name = "nodes.k"
-mesh_file = DownloadManager().download_file(
-    mesh_file_name, "ls-dyna", "John_Reid_Pipe", destination=os.path.join(EXAMPLES_PATH, "John_Reid_Pipe")
+mesh_file = download_manager.download_file(
+    mesh_file_name, "ls-dyna/John_Reid_Pipe", destination=os.path.join(EXAMPLES_PATH, "John_Reid_Pipe")
 )
 
 rundir = tempfile.TemporaryDirectory()

--- a/examples/Optimization/Plate_Thickness_Optimization.py
+++ b/examples/Optimization/Plate_Thickness_Optimization.py
@@ -51,7 +51,7 @@ from ansys.dyna.core import Deck, keywords as kwd
 # from ansys.dyna.core.run.linux_runner import LinuxRunner
 from ansys.dyna.core.run.local_solver import run_dyna
 from ansys.dyna.core.run.options import MemoryUnit, MpiOption, Precision
-from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, DownloadManager
+from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, download_manager
 
 # from ansys.dyna.core.run.windows_runner import WindowsRunner
 
@@ -62,8 +62,8 @@ workdir = tempfile.TemporaryDirectory()
 
 mesh_file_name = "bar_impact_mesh.k"
 
-mesh_file = DownloadManager().download_file(
-    mesh_file_name, "ls-dyna", "Bar_Impact", destination=os.path.join(EXAMPLES_PATH, "Bar_Impact")
+mesh_file = download_manager.download_file(
+    mesh_file_name, "ls-dyna/Bar_Impact", destination=os.path.join(EXAMPLES_PATH, "Bar_Impact")
 )
 
 # If you'd like to insert your own path to a local mesh file you can do so by replacing the line

--- a/examples/Taylor_Bar/plot_taylor_bar.py
+++ b/examples/Taylor_Bar/plot_taylor_bar.py
@@ -49,13 +49,13 @@ import matplotlib.pyplot as plt
 
 from ansys.dyna.core import Deck, keywords as kwd
 from ansys.dyna.core.run import run_dyna
-from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, DownloadManager
+from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, download_manager
 
 workdir = tempfile.TemporaryDirectory()
 
 mesh_file_name = "taylor_bar_mesh.k"
-mesh_file = DownloadManager().download_file(
-    mesh_file_name, "ls-dyna", "Taylor_Bar", destination=os.path.join(EXAMPLES_PATH, "Taylor_Bar")
+mesh_file = download_manager.download_file(
+    mesh_file_name, "ls-dyna/Taylor_Bar", destination=os.path.join(EXAMPLES_PATH, "Taylor_Bar")
 )
 
 ###############################################################################

--- a/src/ansys/dyna/core/keywords/__init__.py
+++ b/src/ansys/dyna/core/keywords/__init__.py
@@ -22,18 +22,6 @@
 
 """ANSYS Dyna Keywords Module."""
 
-import os
-
-import appdirs
-
-__all__ = ["keywords", "EXAMPLES_PATH", "USER_DATA_PATH"]
+__all__ = ["keywords"]
 
 import ansys.dyna.core.keywords.keyword_classes as keywords  # noqa: F401
-
-USER_DATA_PATH = appdirs.user_data_dir(appname="ansys_dyna_keywords", appauthor="Ansys")
-if not os.path.exists(USER_DATA_PATH):
-    os.makedirs(USER_DATA_PATH)
-
-EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
-if not os.path.exists(EXAMPLES_PATH):
-    os.makedirs(EXAMPLES_PATH)

--- a/src/ansys/dyna/core/utils/download_utilities.py
+++ b/src/ansys/dyna/core/utils/download_utilities.py
@@ -38,11 +38,6 @@ except ModuleNotFoundError:
     USER_NAME = os.getenv("USERNAME", os.getenv("USER", "pydyna"))
     USER_DATA_PATH = os.getenv("PYDYNA_USER_DATA", os.path.join(tempfile.gettempdir(), USER_NAME))
 
-if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
-    os.makedirs(USER_DATA_PATH)
-
 EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
-if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
-    os.makedirs(EXAMPLES_PATH)
 
 __all__ = ["download_manager", "EXAMPLES_PATH", "USER_DATA_PATH"]

--- a/src/ansys/dyna/core/utils/download_utilities.py
+++ b/src/ansys/dyna/core/utils/download_utilities.py
@@ -20,13 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Module provides a thread-safe singleton download manager for handling example file downloads."""
+"""Module provides example download utilities backed by ``ansys-tools-common``."""
 
 import os
-from threading import Lock
-from typing import Optional
-from urllib.parse import urljoin, urlparse
-import urllib.request
+
+from ansys.tools.common.example_download import download_manager  # noqa: F401
 
 try:
     import appdirs
@@ -47,138 +45,4 @@ EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
 if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
     os.makedirs(EXAMPLES_PATH)
 
-__all__ = ["DownloadManager"]
-
-
-class DownloadManagerMeta(type):
-    """
-    Download Manager Metaclass.
-
-    Provides a thread-safe implementation of ``Singleton`` from
-    https://refactoring.guru/design-patterns/singleton/python/example#example-1.
-
-    """
-
-    _instances = {}
-    _lock: Lock = Lock()
-
-    def __call__(cls, *args, **kwargs):
-        """Create or return the singleton instance.
-
-        Possible changes to the value of the ``__init__`` argument do not affect
-        the returned instance.
-        """
-        with cls._lock:
-            if cls not in cls._instances:
-                instance = super().__call__(*args, **kwargs)
-                cls._instances[cls] = instance
-        return cls._instances[cls]
-
-
-class DownloadManager(metaclass=DownloadManagerMeta):
-    """Manages downloads of example files.
-
-    Local paths are saved in this class so that a global cleanup
-    of example files can be performed when the client is closed.
-    """
-
-    def __init__(self):
-        self.downloads_list = []
-
-    def add_file(self, file_path: str):
-        """Add the path for a downloaded example file to a list.
-
-        This list keeps track of where example files are
-        downloaded so that a global cleanup of these files can be
-        performed when the client is closed.
-
-        Parameters
-        ----------
-        file_path : str
-            Local path of the downloaded example file.
-        """
-        self.downloads_list.append(file_path)
-
-    def clear_download_cache(self):
-        """Remove downloaded example files from the local path."""
-        for file in self.downloads_list:
-            os.remove(file)
-        self.downloads_list.clear()
-
-    def download_file(
-        self, filename: str, *directory: str, destination: Optional[str] = None, force: bool = False
-    ) -> str:
-        """Download an example file from the PyAnsys Github examples repository.
-
-        Parameters
-        ----------
-        filename : str
-            Name of the example file to download.
-        destination : str, optional
-            Path to download the example file to. The default
-            is ``None``, in which case the default path for app data
-            is used.
-        force : bool, optional
-            Whether to always download the example file. The default is
-            ``False``, in which case if the example file is cached, it
-            is reused.
-        directory : tuple[str]
-            Path under the PyAnsys Github examples repository.
-
-        Returns
-        -------
-        tuple[str, str]
-            Tuple containing the filepath to use and the local filepath of the downloaded
-            directory. The two are different in case of containers.
-
-        """
-        # if destination is not a dir create it
-        if destination is not None and not os.path.isdir(destination):
-            os.mkdir(destination)
-
-        # check if it was able to create the dir
-        if destination is not None and not os.path.isdir(destination):
-            raise ValueError("destination directory provided does not exist")
-
-        url = self._get_filepath_on_default_server(filename, *directory)
-        local_path = self._retrieve_data(url, filename, dest=destination, force=force)
-
-        # add path to downloaded files
-        self.add_file(local_path)
-        return local_path
-
-    def _joinurl(self, base, *paths):
-        for path in paths:
-            if base[-1] != "/":
-                base += "/"
-            base = urljoin(base, path)
-        return base
-
-    def _get_default_server_and_joiner(self):
-        return "https://github.com/ansys/example-data/raw/main", self._joinurl
-
-    def _get_filepath_on_default_server(self, filename: str, *directory: str):
-        server, joiner = self._get_default_server_and_joiner()
-        if directory:
-            return joiner(server, *directory, filename)
-        else:
-            return joiner(server, filename)
-
-    def _retrieve_url(self, url, dest):
-        parsed_url = urlparse(url)
-        allowed_schemes = {"http", "https", "ftp"}
-        if parsed_url.scheme not in allowed_schemes:
-            raise ValueError(f"URL scheme '{parsed_url.scheme}' not allowed for download.")
-        # Ignore the B310 warning as this is a safe use of urllib
-        # as it is used to download files from a trusted source.
-        saved_file, _ = urllib.request.urlretrieve(url, filename=dest)  # nosec: B310
-        return saved_file
-
-    def _retrieve_data(self, url: str, filename: str, dest: str = None, force: bool = False):
-        if dest == None:
-            dest = EXAMPLES_PATH
-        local_path = os.path.join(dest, os.path.basename(filename))
-        if not force and os.path.isfile(local_path):
-            return local_path
-        local_path = self._retrieve_url(url, local_path)
-        return local_path
+__all__ = ["download_manager", "EXAMPLES_PATH", "USER_DATA_PATH"]

--- a/tests/test_download_utilities.py
+++ b/tests/test_download_utilities.py
@@ -1,0 +1,259 @@
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the download_utilities module.
+
+The module wraps ``ansys-tools-common``'s ``download_manager`` singleton and
+exposes ``EXAMPLES_PATH`` / ``USER_DATA_PATH`` convenience constants.
+
+Test organisation
+-----------------
+``TestModuleExports``       – fast, no network (constants & singleton identity)
+``TestDownloadManagerUnit`` – fast, no network (behaviour mocked at method level)
+``test_download_*``         – integration, requires network (real example files)
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Upstream singleton used to verify identity
+from ansys.tools.common.example_download import download_manager as _upstream_dm
+
+from ansys.dyna.core.utils.download_utilities import EXAMPLES_PATH, USER_DATA_PATH, download_manager
+
+
+# Real example files used by the pydyna example scripts (examples/ directory).
+# Format: (filename, directory-under-example-data-repo)
+_EXAMPLE_FILES = [
+    pytest.param("mesh.k", "ls-dyna/Buckling_Beer_Can", id="buckling_beer_can"),
+    pytest.param("nodes.k", "ls-dyna/John_Reid_Pendulum", id="john_reid_pendulum"),
+    pytest.param("nodes.k", "ls-dyna/John_Reid_Pipe", id="john_reid_pipe"),
+    pytest.param("taylor_bar_mesh.k", "ls-dyna/Taylor_Bar", id="taylor_bar"),
+    pytest.param("bar_impact_mesh.k", "ls-dyna/Bar_Impact", id="bar_impact"),
+]
+
+# Module-level exports
+
+class TestModuleExports:
+    """Verify that the module re-exports the expected symbols with correct types."""
+
+    def test_download_manager_is_upstream_singleton(self):
+        """``download_manager`` must be the same object as the upstream singleton."""
+        assert download_manager is _upstream_dm
+
+    def test_all_exports_defined(self):
+        import ansys.dyna.core.utils.download_utilities as du
+
+        assert set(du.__all__) == {"download_manager", "EXAMPLES_PATH", "USER_DATA_PATH"}
+
+    def test_user_data_path_is_string(self):
+        assert isinstance(USER_DATA_PATH, str)
+
+    def test_examples_path_is_string(self):
+        assert isinstance(EXAMPLES_PATH, str)
+
+    def test_examples_path_is_examples_subdir_of_user_data_path(self):
+        assert Path(EXAMPLES_PATH) == Path(USER_DATA_PATH) / "examples"
+
+    def test_examples_path_directory_exists(self):
+        assert os.path.isdir(EXAMPLES_PATH)
+
+    def test_user_data_path_directory_exists(self):
+        assert os.path.isdir(USER_DATA_PATH)
+
+
+
+# Unit tests – network calls mocked at the private-method boundary
+
+class TestDownloadManagerUnit:
+    """Behaviour tests that do not touch the network."""
+
+    def test_download_file_is_callable(self):
+        assert callable(download_manager.download_file)
+
+    def test_clear_download_cache_is_callable(self):
+        assert callable(download_manager.clear_download_cache)
+
+    def test_download_file_creates_missing_destination_directory(self, tmp_path):
+        dest = tmp_path / "new_example_dir"
+        assert not dest.exists()
+
+        with (
+            patch.object(
+                download_manager,
+                "_download_file_git_based",
+                side_effect=RuntimeError("git unavailable"),
+            ),
+            patch.object(
+                download_manager,
+                "_download_file_http_based",
+                return_value=str(dest / "mesh.k"),
+            ),
+            patch.object(download_manager, "_add_file"),
+        ):
+            download_manager.download_file("mesh.k", "ls-dyna/Buckling_Beer_Can", destination=str(dest))
+
+        assert dest.is_dir()
+
+    def test_download_file_returns_local_path(self, tmp_path):
+        expected = str(tmp_path / "mesh.k")
+
+        with (
+            patch.object(
+                download_manager,
+                "_download_file_git_based",
+                side_effect=RuntimeError("git unavailable"),
+            ),
+            patch.object(
+                download_manager,
+                "_download_file_http_based",
+                return_value=expected,
+            ),
+            patch.object(download_manager, "_add_file"),
+        ):
+            result = download_manager.download_file(
+                "mesh.k", "ls-dyna/Buckling_Beer_Can", destination=str(tmp_path)
+            )
+
+        assert result == expected
+
+    def test_download_file_force_bypasses_cache(self, tmp_path):
+        """force=True must reach the HTTP download even when a cached file exists."""
+        cached = tmp_path / "mesh.k"
+        cached.write_bytes(b"stale content")
+        expected = str(cached)
+
+        with (
+            patch.object(
+                download_manager,
+                "_download_file_git_based",
+                side_effect=RuntimeError("git unavailable"),
+            ),
+            patch.object(
+                download_manager,
+                "_download_file_http_based",
+                return_value=expected,
+            ) as mock_http,
+            patch.object(download_manager, "_add_file"),
+        ):
+            download_manager.download_file(
+                "mesh.k", "ls-dyna/Buckling_Beer_Can", destination=str(tmp_path), force=True
+            )
+
+        mock_http.assert_called_once()
+
+    def test_download_file_no_force_skips_network_for_cached_file(self, tmp_path):
+        """force=False must not issue any HTTP request when the file is already cached.
+
+        The caching check in ``_retrieve_data`` returns the cached path before
+        calling ``requests.get``, so no network I/O should occur.
+        """
+        import requests
+
+        cached = tmp_path / "mesh.k"
+        cached.write_bytes(b"cached content")
+
+        with (
+            patch.object(
+                download_manager,
+                "_download_file_git_based",
+                side_effect=RuntimeError("git unavailable"),
+            ),
+            patch.object(download_manager, "_add_file"),
+            patch.object(requests, "get") as mock_get,
+        ):
+            result = download_manager.download_file(
+                "mesh.k", "ls-dyna/Buckling_Beer_Can", destination=str(tmp_path), force=False
+            )
+
+        mock_get.assert_not_called()
+        assert result == str(cached)
+
+    def test_clear_download_cache_removes_tracked_files(self, tmp_path):
+        """clear_download_cache() must delete all files in the internal tracking list."""
+        tracked = tmp_path / "tracked.k"
+        tracked.write_bytes(b"content")
+
+        original_list = list(download_manager._downloads_list)
+        download_manager._downloads_list.clear()
+        download_manager._downloads_list.append(str(tracked))
+
+        try:
+            download_manager.clear_download_cache()
+            assert not tracked.exists()
+            assert len(download_manager._downloads_list) == 0
+        finally:
+            # Restore the list so other tests are unaffected
+            download_manager._downloads_list.extend(original_list)
+
+
+
+# Integration tests – require network access to github.com/ansys/example-data
+
+@pytest.mark.parametrize("filename,directory", _EXAMPLE_FILES)
+def test_download_example_file(filename, directory, tmp_path):
+    """Download each real example file referenced by pydyna example scripts."""
+    dest = tmp_path / directory.split("/")[-1]
+
+    local_path = download_manager.download_file(filename, directory, destination=str(dest))
+
+    assert os.path.isfile(local_path), f"Expected file not found: {local_path}"
+    assert os.path.getsize(local_path) > 0, f"Downloaded file is empty: {local_path}"
+    assert Path(local_path).name == filename
+
+
+def test_download_file_caches_result(tmp_path):
+    """A second non-forced download of the same file must reuse the cached copy."""
+    filename = "mesh.k"
+    directory = "ls-dyna/Buckling_Beer_Can"
+    dest = tmp_path / "cache_test"
+
+    path1 = download_manager.download_file(filename, directory, destination=str(dest))
+    mtime1 = os.path.getmtime(path1)
+
+    path2 = download_manager.download_file(filename, directory, destination=str(dest), force=False)
+    mtime2 = os.path.getmtime(path2)
+
+    assert path1 == path2
+    assert mtime1 == mtime2, "Cached file was unexpectedly overwritten"
+
+
+def test_download_file_force_refreshes_cached_file(tmp_path):
+    """force=True must overwrite a pre-existing file and return its path."""
+    filename = "mesh.k"
+    directory = "ls-dyna/Buckling_Beer_Can"
+    dest = tmp_path / "force_test"
+
+    # Populate cache with a stale placeholder
+    dest.mkdir()
+    stale = dest / filename
+    stale.write_bytes(b"stale")
+    mtime_before = os.path.getmtime(str(stale))
+
+    refreshed_path = download_manager.download_file(filename, directory, destination=str(dest), force=True)
+
+    assert os.path.isfile(refreshed_path)
+    assert os.path.getsize(refreshed_path) > len(b"stale")
+    assert os.path.getmtime(refreshed_path) >= mtime_before

--- a/tests/test_download_utilities.py
+++ b/tests/test_download_utilities.py
@@ -77,12 +77,6 @@ class TestModuleExports:
     def test_examples_path_is_examples_subdir_of_user_data_path(self):
         assert Path(EXAMPLES_PATH) == Path(USER_DATA_PATH) / "examples"
 
-    def test_examples_path_directory_exists(self):
-        assert os.path.isdir(EXAMPLES_PATH)
-
-    def test_user_data_path_directory_exists(self):
-        assert os.path.isdir(USER_DATA_PATH)
-
 
 
 # Unit tests – network calls mocked at the private-method boundary


### PR DESCRIPTION
fix #1227  

Replace custom `DownloadManager` implementation with `download_manager` from `ansys-tools-common`

 Closes #1233 — since this PR already migrates the download manager to the `ansys-tools-common` singleton, it was the natural place to also remove the `os.makedirs` calls that ran at import time in both `keywords/__init__.py` and download_utilities.py, eliminating the filesystem side-effects reported in the issue.