### PR TITLE
docs: add deprecation banner to `info`

### DIFF
--- a/doc/changelog/1311.dependencies.md
+++ b/doc/changelog/1311.dependencies.md
@@ -1,0 +1,1 @@
+Docs: add deprecation banner to \`info\`

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -151,7 +151,12 @@ html_theme_options = {
         ],
         "output": "api",
     },
-    "announcement": "<style>.bd-header-announcement{background-color:#f2bebd;}The </style><span>ansys.dyna.core.pre</span> and <span>ansys.dyna.core.run</span> subpackages are removed in version v0.11.0.",
+    "announcement_banner": [
+    {
+        "message": "The 'ansys.dyna.core.pre' and 'ansys.dyna.core.run' subpackages are removed in version v0.11.0.",
+        "type": "info",
+    },
+    ],
 }
 
 # static path

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -153,7 +153,7 @@ html_theme_options = {
     },
     "announcement_banner": [
     {
-        "message": "The 'ansys.dyna.core.pre' and 'ansys.dyna.core.run' subpackages are removed in version v0.11.0.",
+        "message": "The 'ansys.dyna.core.pre' and 'ansys.dyna.core.run' subpackages were removed in version v0.11.0.",
         "type": "info",
     },
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ doc = [
     "sphinx-copybutton==0.5.2",
     "sphinx-gallery==0.21.0",
     "sphinx-autodoc-typehints==3.1.0",
-    "ansys-sphinx-theme[autoapi]==1.9.0",
+    "ansys-sphinx-theme[autoapi]==1.10.0",
     "pypandoc==1.17",
     "nbsphinx==0.9.8",
     "joblib==1.5.3",


### PR DESCRIPTION
- Use latest theme banner and make the deprecation banner from breaking to info.

## before
<img width="1259" height="719" alt="Screenshot 2026-08-20 at 19 17 50" src="https://github.com/user-attachments/assets/b8288f96-8ec9-4567-8919-319fbf64d4d5" />

## after
<img width="1335" height="551" alt="Screenshot 2026-08-20 at 19 17 38" src="https://github.com/user-attachments/assets/9472c574-2822-46a3-8ec9-6d62f031d5d5" />
